### PR TITLE
Add references to the auth object on every request to match the spec

### DIFF
--- a/src/layouts/docs/menu-contents.ts
+++ b/src/layouts/docs/menu-contents.ts
@@ -101,6 +101,7 @@ export const menu: MenuContents = [
         title: "Reference",
         menuItems: [
           { title: "Address", href: "/docs/v2/reference/address#order-source-address-object" },
+          { title: "Auth", href: "/docs/v2/reference/auth" },
           { title: "BillTo", href: "/docs/v2/reference/address#billto-address-object" },
           { title: "Branding", href: "/docs/v2/reference/branding" },
           { title: "Buyer", href: "/docs/v2/reference/buyer" },

--- a/src/pages/docs/v2/reference/auth.mdx
+++ b/src/pages/docs/v2/reference/auth.mdx
@@ -1,0 +1,56 @@
+---
+title: auth object
+description: An object representing auth.
+---
+
+Auth Object
+===============================================
+A auth object used to contain unique user information persistant across multiple request/reponses.
+Example properties would be `username`, `password`, `api_key`, or `access_token`, depending on the type of authentication, but not all auth types will have all properties.
+Any field in the connection modal which does not fall under one of the above categories will be grouped into the `connection_context` object.
+
+<Reference>
+
+  <Field name="order_source_api_code" type="string">
+    <Description>
+      The unique identifier for the type of order source
+    </Description>
+  </Field>
+
+  <Field name="username" type="string" required={false}>
+    <Description>
+      The username of the seller making the request for this order source
+    </Description>
+  </Field>
+
+  <Field name="password" type="string" required={false}>
+    <Description>
+      The password of the seller making the request for this order source
+    </Description>
+  </Field>
+
+  <Field name="access_token" type="string" required={false}>
+    <Description>
+      The access token of the seller making the request for this order source
+    </Description>
+  </Field>
+
+  <Field name="api_key" type="string" required={false}>
+    <Description>
+      The api key token of the seller making the request for this order source
+    </Description>
+  </Field>
+
+  <Field name="url" type="string" required={false}>
+    <Description>
+      The url of the sellers store, only used in cases where the 3rd party api can be hosted on a seller by seller basis
+    </Description>
+  </Field>
+
+  <Field name="connection_context" type="object" required={false}>
+    <Description>
+      Additional source-specific information needed to connect to the API
+    </Description>
+  </Field>
+
+</Reference>

--- a/src/pages/docs/v2/reference/methods/accept-sales-order-items.mdx
+++ b/src/pages/docs/v2/reference/methods/accept-sales-order-items.mdx
@@ -45,7 +45,7 @@ A list of requests to accept orders in an order source.
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/accept-sales-order-items.mdx
+++ b/src/pages/docs/v2/reference/methods/accept-sales-order-items.mdx
@@ -43,6 +43,15 @@ A list of requests to accept orders in an order source.
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="notifications" nullable={false}>
     <Type>
       [accept sales order items notification object[]](#AcceptSalesOrderItems)

--- a/src/pages/docs/v2/reference/methods/acknowledge-orders.mdx
+++ b/src/pages/docs/v2/reference/methods/acknowledge-orders.mdx
@@ -42,6 +42,15 @@ An object containing parameters to use when acknowledging orders to an order sou
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="orders" nullable={false}>
     <Type>
       [order acknowledge object[]](#orderacknowledgement)

--- a/src/pages/docs/v2/reference/methods/acknowledge-orders.mdx
+++ b/src/pages/docs/v2/reference/methods/acknowledge-orders.mdx
@@ -44,7 +44,7 @@ An object containing parameters to use when acknowledging orders to an order sou
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/cancel-sales-order-items.mdx
+++ b/src/pages/docs/v2/reference/methods/cancel-sales-order-items.mdx
@@ -42,6 +42,15 @@ A list of requests to cancel items on orders in an order source.
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="notifications" nullable={false}>
     <Type>
       [cancel sales order items notification object[]](#CancelSalesOrderItems)

--- a/src/pages/docs/v2/reference/methods/cancel-sales-order-items.mdx
+++ b/src/pages/docs/v2/reference/methods/cancel-sales-order-items.mdx
@@ -44,7 +44,7 @@ A list of requests to cancel items on orders in an order source.
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/get-products.mdx
+++ b/src/pages/docs/v2/reference/methods/get-products.mdx
@@ -41,6 +41,15 @@ An object containing parameters to use when querying products from an order sour
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="product_ids" type="string[]" nullable={true}>
     <Description>
       A list of product ids to get data from the order source.

--- a/src/pages/docs/v2/reference/methods/get-products.mdx
+++ b/src/pages/docs/v2/reference/methods/get-products.mdx
@@ -43,7 +43,7 @@ An object containing parameters to use when querying products from an order sour
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/notification-status.mdx
+++ b/src/pages/docs/v2/reference/methods/notification-status.mdx
@@ -44,7 +44,7 @@ A request to notify an order source that a order has been shipped.
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/notification-status.mdx
+++ b/src/pages/docs/v2/reference/methods/notification-status.mdx
@@ -42,6 +42,15 @@ A request to notify an order source that a order has been shipped.
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="notifications" nullable={false}>
     <Type>
       [pending notification object[]](#pendingnotification)

--- a/src/pages/docs/v2/reference/methods/register-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/register-delivery-options.mdx
@@ -44,7 +44,7 @@ An object containing parameters to use when registering delivery options with an
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/register-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/register-delivery-options.mdx
@@ -42,6 +42,15 @@ An object containing parameters to use when registering delivery options with an
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="callback_url" type="string" nullable={false}>
     <Description>
       Callback url to register with the order source.

--- a/src/pages/docs/v2/reference/methods/remove-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/remove-delivery-options.mdx
@@ -42,6 +42,15 @@ An object containing parameters to use when removing delivery options from an or
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="connection_id" type="string" required={true}>
     <Description>
       The unique identifier for the connection from the order source.

--- a/src/pages/docs/v2/reference/methods/remove-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/remove-delivery-options.mdx
@@ -44,7 +44,7 @@ An object containing parameters to use when removing delivery options from an or
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/sales-orders-export.mdx
+++ b/src/pages/docs/v2/reference/methods/sales-orders-export.mdx
@@ -43,7 +43,7 @@ An object containing parameters to use when querying the order source for sales 
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/sales-orders-export.mdx
+++ b/src/pages/docs/v2/reference/methods/sales-orders-export.mdx
@@ -41,6 +41,15 @@ An object containing parameters to use when querying the order source for sales 
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="criteria" type="object" nullable={true}>
     <Description>
       This object will contain properies that help create the search query to poll the order source for sales orders.

--- a/src/pages/docs/v2/reference/methods/shipment-notification.mdx
+++ b/src/pages/docs/v2/reference/methods/shipment-notification.mdx
@@ -44,6 +44,15 @@ A request to notify an order source that a order has been shipped.
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="notifications" nullable={false}>
     <Type>
       [shipment notification object[]](#shipmentnotification)

--- a/src/pages/docs/v2/reference/methods/shipment-notification.mdx
+++ b/src/pages/docs/v2/reference/methods/shipment-notification.mdx
@@ -46,7 +46,7 @@ A request to notify an order source that a order has been shipped.
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/verify-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/verify-delivery-options.mdx
@@ -50,7 +50,7 @@ Return Value
 
   <Field name="auth" nullable={false}>
     <Type>
-      [auth object](#auth)
+      [auth object](./../auth.mdx)
     </Type>
     <Description>
       Represents the auth information sent with every request

--- a/src/pages/docs/v2/reference/methods/verify-delivery-options.mdx
+++ b/src/pages/docs/v2/reference/methods/verify-delivery-options.mdx
@@ -48,6 +48,15 @@ Return Value
 
 <Reference>
 
+  <Field name="auth" nullable={false}>
+    <Type>
+      [auth object](#auth)
+    </Type>
+    <Description>
+      Represents the auth information sent with every request
+    </Description>
+  </Field>
+
   <Field name="is_supported" type="string" required={true}>
     <Description>
       Indicates whether or not delivery options is supported in the order source. 


### PR DESCRIPTION
The current public docs don't explicitly call out the `auth` object, and also doesn't mention that all OrderSourceAPI requests inherit it from `RequestBase`. Including the field on every method page should reduce confusion.