### PR TITLE
Add descriptions to SalesOrderStatus

### DIFF
--- a/src/pages/docs/reference/sales-order-status.mdx
+++ b/src/pages/docs/reference/sales-order-status.mdx
@@ -9,32 +9,32 @@ The status of a sales order
 
 <Reference>  <Field name="AwaitingPayment">
     <Description>
-      "AwaitingPayment" - 
+      For orders which have been placed but not yet paid for, and should not be shipped until the payment clears.
     </Description>
   </Field>
   <Field name="AwaitingShipment">
     <Description>
-      "AwaitingShipment" - 
+      For orders which are ready to be shipped and require action from the seller.
     </Description>
   </Field>
   <Field name="Cancelled">
     <Description>
-      "Cancelled" - 
+      For orders which have been cancelled by the buyer.
     </Description>
   </Field>
   <Field name="Completed">
     <Description>
-      "Completed" - 
+      For orders which have already been shipped in full.
     </Description>
   </Field>
   <Field name="OnHold">
     <Description>
-      "OnHold" - 
+      Orders imported with the "OnHold" status require attention or approval from the seller before moving to "AwaitingShipment".
     </Description>
   </Field>
   <Field name="PendingFulfillment">
     <Description>
-      "PendingFulfillment" - 
+      Orders in the "PendingFulfillment" status have been delegated to a 3rd party fulfiller to be shipped, and it is not expected that the seller perform additional action to ship the order.
     </Description>
   </Field>
 </Reference>


### PR DESCRIPTION
The current version of this page doesn't really provide any information, so this should clear up some confusion for developers unfamiliar with ShipStation's statuses.