### PR TITLE
Updating contact method for Connect team

### DIFF
--- a/src/pages/docs/oauth/index.mdx
+++ b/src/pages/docs/oauth/index.mdx
@@ -72,7 +72,7 @@ The next step will be to publish your application using the `connect publish` co
 ## Request An Installation
 > **INFO:** Your application must be published in order to have our platform establish an `OAuth Installation`, this installation process only needs to happen once and will tell our platform to start consuming your AuthProcess definition.
 
-- Contact a member of the [ShipEngine Connect Team](https://help.shipengine.com/hc/en-us) in order to establish a the platform installation
+- Contact a member of the [ShipEngine Connect Team](mailto:connect@shipengine.com?subject=OAuth%20Installation) in order to establish a the platform installation
     - Provide a ClientId & ClientSecret used for initiating the oauth workflow
 - Once the installation has been created you will recieve back a callback url
 


### PR DESCRIPTION
Old link for contacting Connect team to setup OAuth install doesn't provide a clear path to the actual contact method. Changing to email address. 