### PR TITLE
Add the other possible source weight units to the CAPI docs

### DIFF
--- a/src/pages/docs/reference/units.mdx
+++ b/src/pages/docs/reference/units.mdx
@@ -92,7 +92,7 @@ This model represents the weight of a package represented in its original unit, 
 
   <Field name="source_weight_unit" type="string" nullable={false}>
     <Description>
-      The unit of the source dimensions. Either ounces or grams.
+      The unit of the source dimensions. Could be 'ounces', 'pounds', 'grams', or 'kilograms'.
     </Description>
   </Field>
 </Reference>


### PR DESCRIPTION
The carrier API spec allows more `source_weight_units` than we had previously documented in Connect.