### PR TITLE
Api Codes & GetConnectionContext

### DIFF
--- a/src/layouts/docs/menu-contents.ts
+++ b/src/layouts/docs/menu-contents.ts
@@ -171,6 +171,10 @@ export const menu: MenuContents = [
             title: "CancelSalesOrderItems",
             href: "/docs/reference/methods/cancel-sales-order-items",
           },
+          {
+            title: "GetConnectionContext",
+            href: "/docs/reference/methods/get-connection-context",
+          },
         ],
       },
       {
@@ -351,6 +355,14 @@ export const menu: MenuContents = [
           {
             "title": "RequestedCancelProduct",
             "href": "/docs/reference/requested-cancel-product"
+          },
+          {
+            "title": "GetConnectionContextRequest",
+            "href": "/docs/reference/get-connection-context-request"
+          },
+          {
+            "title": "GetConnectionContextResponse",
+            "href": "/docs/reference/get-connection-context-response"
           },
           {
             "title": "GetProductsRequest",

--- a/src/pages/docs/app-definition/carrier.mdx
+++ b/src/pages/docs/app-definition/carrier.mdx
@@ -52,6 +52,12 @@ tags:
     </Description>
     </Field>
 
+    <Field name="ApiCode" type="string" nullable={true} required={false}>
+    <Description>
+      The identifier for this carrier to be used in API calls. Must be snake cased and unique.
+    </Description>
+    </Field>
+
     <Field name="Description" type="string" nullable={true} required={false}>
     <Description>
       This is a human readable description of the branded carrier
@@ -185,6 +191,12 @@ tags:
     </Description>
     </Field>
 
+    <Field name="ApiCode" type="string" nullable={true} required={false}>
+    <Description>
+      The identifier for this package type to be used in API calls. Must be snake cased and unique.
+    </Description>
+    </Field>
+
     <Field name="CarrierPackageTypeCode" type="string" nullable={false} required={true}>
     <Description>
       This is the code that will be sent to requests, this should be the same code the carrier's api would expect
@@ -229,6 +241,12 @@ tags:
     <Field name="Name" type="string" nullable={false} required={true}>
     <Description>
       The name of this shipping service ex: 'Overnight Guarantee'
+    </Description>
+    </Field>
+
+    <Field name="ApiCode" type="string" nullable={true} required={false}>
+    <Description>
+      The identifier for this shipping service to be used in API calls. Must be snake cased and unique.
     </Description>
     </Field>
 

--- a/src/pages/docs/app-definition/order-source.mdx
+++ b/src/pages/docs/app-definition/order-source.mdx
@@ -25,6 +25,12 @@ The code for your app definition can be seen [here on github](https://github.com
     </Description>
     </Field>
 
+    <Field name="ApiCode" type="string" nullable={true} required={false}>
+    <Description>
+      The identifier for this order source to be used in API calls. Must be snake cased and unique.
+    </Description>
+    </Field>
+
     <Field name="AuthProcess" type="object" nullable={false} required={true}>
     <Description>
       The [specification](#auth-specification) for authorizing with this order source

--- a/src/pages/docs/reference/get-connection-context-request.mdx
+++ b/src/pages/docs/reference/get-connection-context-request.mdx
@@ -1,0 +1,26 @@
+---
+title: GetConnectionContextRequest
+description: The properties associated with a GetConnectionContextRequest
+---
+
+GetConnectionContextRequest
+===============================================
+
+This request is sent after a user authenticates with the third party,
+this allows you the chance to fetch additional properties and append them onto the connection_context.
+
+<Reference>
+  <Field name="auth" nullable={false}>
+    <Type>
+      [Auth](./auth.mdx)
+    </Type>
+    <Description>
+      The authorization information necessary to fulfill this request.
+    </Description>
+  </Field>
+  <Field name="transaction_id" type="string" nullable={false}>
+    <Description>
+      A randomly generated transaction ID, used to correlate the request and response
+    </Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/get-connection-context-response.mdx
+++ b/src/pages/docs/reference/get-connection-context-response.mdx
@@ -1,0 +1,17 @@
+---
+title: GetConnectionContextResponse
+description: The properties associated with a GetConnectionContextResponse
+---
+
+GetConnectionContextResponse
+===============================================
+The connection context response which will allow you to update the connection_context for all future requests.
+
+<Reference>
+  <Field name="connection_context" type="object" nullable={false}>
+    <Description>
+      The connection context that will be sent as part of the auth.connection_context for other requests.
+      ex: ```{ 'user_id': 'fake_234', 'store_id': '12324' }```
+    </Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/methods/get-connection-context.mdx
+++ b/src/pages/docs/reference/methods/get-connection-context.mdx
@@ -1,0 +1,67 @@
+---
+title: GetConnectionContext Method
+description: This method gets additional context for a connection to an order source.
+---
+
+`GetConnectionContext()`
+===========================
+This method is called during store setup with the initial credentials and connection context provided
+by the seller, and returns any additional context for the connection to the order source.
+
+
+Syntax
+-----------------------------------------------
+<CodeWrapper>
+```javascript
+module.exports = async function GetConnectionContext(request) {
+  // Your code here
+}
+```
+
+```typescript
+import {
+  GetConnectionContextRequest,
+  GetConnectionContextResponse
+  } from "@shipengine/connect-order-source-api";
+
+export const GetConnectionContext = async (
+  request: GetConnectionContextRequest
+): Promise<GetConnectionContextResponse> => {
+  // Your code here
+}
+```
+</CodeWrapper>
+
+GetConnectionContextRequest
+----
+This request is sent after a user authenticates with the third party,
+this allows you the chance to fetch additional properties and append them onto the connection_context.
+
+<Reference>
+  <Field name="auth" nullable={false}>
+    <Type>
+      [Auth](../auth.mdx)
+    </Type>
+    <Description>
+      The authorization information necessary to fulfill this request.
+    </Description>
+  </Field>
+  <Field name="transaction_id" type="string" nullable={false}>
+    <Description>
+      A randomly generated transaction ID, used to correlate the request and response
+    </Description>
+  </Field>
+</Reference>
+
+GetConnectionContextResponse
+----
+The connection context response which will allow you to update the connection_context for all future requests.
+
+<Reference>
+  <Field name="connection_context" type="object" nullable={false}>
+    <Description>
+      The connection context that will be sent as part of the auth.connection_context for other requests.
+      ex: ```{ 'user_id': 'fake_234', 'store_id': '12324' }```
+    </Description>
+  </Field>
+</Reference>


### PR DESCRIPTION
This adds documentation for some recently added features of the Connect types libraries:

- `GetConnectionContext` for Order Source apps
- `ApiCode` fields in metadata for Order Source & Carrier apps