### PR TITLE
chore: update Address Base Object docs 

### DIFF
--- a/src/pages/docs/reference/carrier-address.mdx
+++ b/src/pages/docs/reference/carrier-address.mdx
@@ -96,8 +96,6 @@ An address object representing address information.
     </Description>
   </Field>
 
-
-
   <Field name="address_metadata" type="object" nullable={true}>
     <Description>
       Schemaless object representing the metadata related to this address.

--- a/src/pages/docs/reference/carrier-address.mdx
+++ b/src/pages/docs/reference/carrier-address.mdx
@@ -89,11 +89,14 @@ An address object representing address information.
     </Description>
   </Field>
 
-  <Field name="is_eu" type="boolean" nullable={true}>
+    <Field name="instructions" type="string" nullable={true}>
     <Description>
-      Indicates whether the country of the shipment address is a member of the EU.
+      Instructions to help the carrier navigate to the address.
+
     </Description>
   </Field>
+
+
 
   <Field name="address_metadata" type="object" nullable={true}>
     <Description>

--- a/src/pages/docs/reference/carrier-address.mdx
+++ b/src/pages/docs/reference/carrier-address.mdx
@@ -92,7 +92,6 @@ An address object representing address information.
     <Field name="instructions" type="string" nullable={true}>
     <Description>
       Instructions to help the carrier navigate to the address.
-
     </Description>
   </Field>
 


### PR DESCRIPTION
Added `instructions` property and removed obsolete `is_eu` property