### PR TITLE
PLAT-4848 Update Website Documentation

### DIFF
--- a/src/pages/docs/app-definition/carrier.mdx
+++ b/src/pages/docs/app-definition/carrier.mdx
@@ -288,7 +288,7 @@ tags:
       [ServiceClassEnum](./../reference/service-class-enum.mdx)
     </Type>
     <Description>
-      The class of service. ex: `Ground`, `OneDay`, `ThreeDay` [info](https://github.com/ShipEngine/connect/blob/2cdd2e17c5eea1e6273937b41fce7c41c7d171ab/packages/carrier-api/src/app/metadata/enums.ts#L23)
+      The class of service. ex: `Ground`, `OneDay`, `ThreeDay`
     </Description>
     </Field>
 
@@ -297,7 +297,7 @@ tags:
       [ServiceGradeEnum](./../reference/service-grade-enum.mdx)
     </Type>
     <Description>
-      The grade of the service. ex: `Economy`, `Expedited`, `Overnight` [info](https://github.com/ShipEngine/connect/blob/2cdd2e17c5eea1e6273937b41fce7c41c7d171ab/packages/carrier-api/src/app/metadata/enums.ts#L34)
+      The grade of the service. ex: `Economy`, `Expedited`, `Overnight` 
     </Description>
     </Field>
 

--- a/src/pages/docs/app-definition/carrier.mdx
+++ b/src/pages/docs/app-definition/carrier.mdx
@@ -82,19 +82,28 @@ tags:
     </Description>
     </Field>
 
-    <Field name="DefaultConfirmationTypes" type="object" nullable={true} required={false}>
+    <Field name="DefaultConfirmationTypes" nullable={true} required={false}>
+    <Type>
+      [ConfirmationDictionary](./../reference/confirmation-dictionary.mdx)
+    </Type>
     <Description>
       This dictionary allows you to specify which supported delivery confirmation types the carrier offers. Setting one to undefined will use the default name in shipstation. 
     </Description>
     </Field>
 
-    <Field name="LabelFormats" type="string[]" nullable={true} required={false}>
+    <Field name="LabelFormats" nullable={true} required={false}>
+      <Type>
+      [LabelFormatsEnum[]](./../reference/label-formats-enum.mdx)
+    </Type>
     <Description>
       This provides a list of label formats supported by the carrier
     </Description>
     </Field>
 
-    <Field name="DefaultLabelSizes" type="string[]" nullable={true} required={false}>
+    <Field name="DefaultLabelSizes" nullable={true} required={false}>
+      <Type>
+      [LabelSizesEnum[]](./../reference/label-sizes-enum.mdx)
+    </Type>
     <Description>
       This provides a list of supported label sizes by the carrier
     </Description>
@@ -274,19 +283,28 @@ tags:
     </Description>
     </Field>
 
-    <Field name="Class" type="string" nullable={true} required={false}>
+    <Field name="Class" nullable={true} required={false}>
+      <Type>
+      [ServiceClassEnum](./../reference/service-class-enum.mdx)
+    </Type>
     <Description>
       The class of service. ex: `Ground`, `OneDay`, `ThreeDay` [info](https://github.com/ShipEngine/connect/blob/2cdd2e17c5eea1e6273937b41fce7c41c7d171ab/packages/carrier-api/src/app/metadata/enums.ts#L23)
     </Description>
     </Field>
 
-    <Field name="Grade" type="string" nullable={true} required={false}>
+    <Field name="Grade" nullable={true} required={false}>
+      <Type>
+      [ServiceGradeEnum](./../reference/service-grade-enum.mdx)
+    </Type>
     <Description>
       The grade of the service. ex: `Economy`, `Expedited`, `Overnight` [info](https://github.com/ShipEngine/connect/blob/2cdd2e17c5eea1e6273937b41fce7c41c7d171ab/packages/carrier-api/src/app/metadata/enums.ts#L34)
     </Description>
     </Field>
 
-    <Field name="SupportedLabelSizes" type="string[]" nullable={true} required={false}>
+    <Field name="SupportedLabelSizes" nullable={true} required={false}>
+      <Type>
+      [LabelSizesEnum[]](./../reference/label-sizes-enum.mdx)
+    </Type>
     <Description>
       A list of label sizes supported by this service
     </Description>
@@ -298,13 +316,19 @@ tags:
     </Description>
     </Field>
 
-    <Field name="ServiceAttributes" type="string[]" nullable={true} required={false}>
+    <Field name="ServiceAttributes" nullable={true} required={false}>
+      <Type>
+      [ServiceAttributesEnum[]](./../reference/service-attributes-enum.mdx)
+    </Type>
     <Description>
       A list of attributes about this service
     </Description>
     </Field>
 
-    <Field name="ConfirmationTypes" type="string[]" nullable={true} required={false}>
+    <Field name="ConfirmationTypes" nullable={true} required={false}>
+    <Type>
+      [ConfirmationType[]](./../reference/confirmation-type.mdx)
+    </Type>
     <Description>
       The confirmation types associated with this service
     </Description>
@@ -321,9 +345,12 @@ tags:
     </Description>
     </Field>
 
-    <Field name="Identifier.AuthenticationType" type="object" nullable={false} required={true}>
+    <Field name="Identifier.AuthenticationType" nullable={false} required={true}>
+      <Type>
+      [AuthenticationType](./../reference/authentication-type.mdx)
+    </Type>
     <Description>
-        Identify the type of Auth being used by the integration (oauth)
+        Identify the type of Auth being used by the integration.
     </Description>
     </Field>
 

--- a/src/pages/docs/reference/advanced-options.mdx
+++ b/src/pages/docs/reference/advanced-options.mdx
@@ -1,0 +1,59 @@
+---
+title: Advanced Options
+description: Basic structure for shipping options
+---
+
+# Advanced Options
+
+Basic structure for shipping options
+
+<Reference>
+  <Field name="contains_alcohol" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Whether the shipment contains alcohol
+    </Description>
+  </Field>
+  <Field name="no_postage" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Whether the shipment does not require postage
+    </Description>
+  </Field>
+  <Field name="nonmachineable" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Whether the shipment can be processed by machine
+    </Description>
+  </Field>
+  <Field name="bill_duties_to_sender" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Whether the shipment duties should be billed to the sender
+    </Description>
+  </Field>
+  <Field name="saturday_delivery" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Whether Saturday delivery is permissible
+    </Description>
+  </Field>
+  <Field name="tip" nullable={true}>
+    <Type>
+      boolean
+    </Type>
+    <Description>
+      Amount to be paid to the driver, used for local delivery and courier services
+    </Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/authentication-type.mdx
+++ b/src/pages/docs/reference/authentication-type.mdx
@@ -1,0 +1,26 @@
+---
+title: Authentication Type
+description: These are the various types of auth that are currently supported by our platform.
+---
+
+# Authentication Type
+
+``` TypeScript
+import { AuthenticationType } from '@shipengine/connect-order-source-api';
+
+AuthenticationType.ApiKey;  // Corresponds to 'apikey'
+AuthenticationType.Basic;   // Corresponds to 'basic'
+AuthenticationType.OAuth;   // Corresponds to 'oauth'
+```
+
+<Reference>
+  <Field name="oauth">
+    <Description>An open standard for access delegation.</Description>
+  </Field>
+  <Field name="basic">
+    <Description>This auth strategy relies on the user providing a username and password.</Description>
+  </Field>
+  <Field name="apikey">
+    <Description>The auth strategy relies on the user providing an api key.</Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/authentication-type.mdx
+++ b/src/pages/docs/reference/authentication-type.mdx
@@ -5,7 +5,7 @@ description: These are the various types of auth that are currently supported by
 
 # Authentication Type
 
-``` TypeScript
+```typescript
 import { AuthenticationType } from '@shipengine/connect-order-source-api';
 
 AuthenticationType.ApiKey;  // Corresponds to 'apikey'

--- a/src/pages/docs/reference/confirmation-dictionary.mdx
+++ b/src/pages/docs/reference/confirmation-dictionary.mdx
@@ -7,7 +7,7 @@ description: This will customize how each potential confirmation type is display
 
 This will customize how each potential confirmation type is displayed to users
 
-``` TypeScript
+```typescript
 import { ConfirmationDictionary } from '@shipengine/connect-carrier-api';
 
 // Specified values will be shown as options to users

--- a/src/pages/docs/reference/confirmation-dictionary.mdx
+++ b/src/pages/docs/reference/confirmation-dictionary.mdx
@@ -1,0 +1,62 @@
+---
+title: Confirmation Dictionary
+description: This will customize how each potential confirmation type is displayed to users
+---
+
+# Confirmation Dictionary
+
+This will customize how each potential confirmation type is displayed to users
+
+``` TypeScript
+import { ConfirmationDictionary } from '@shipengine/connect-carrier-api';
+
+// Specified values will be shown as options to users
+// The string value will be the text displayed to a user
+const supportedConfirmationTypes: ConfirmationDictionary = {
+    None: 'No Confirmation Required', // On Requests 'None' will be sent as the 'confirmation'
+    Signature: 'Signature Required' // On Requests 'Signature' will be sent as the 'confirmation'
+}
+```
+
+<Reference>
+  <Field name="None" nullable={true}>
+    <Type>
+      string
+    </Type>
+    <Description>
+      No confirmation is requested
+    </Description>
+  </Field>
+  <Field name="Delivery" nullable={true}>
+    <Type>
+      string
+    </Type>
+    <Description>
+      Delivery confirmation is requested
+    </Description>
+  </Field>
+  <Field name="Signature" nullable={true}>
+    <Type>
+      string
+    </Type>
+    <Description>
+      A signature is required. This signature may be a neighbor, building manager, or the recipient can authorize the release of the package (without being present)
+    </Description>
+  </Field>
+  <Field name="AdultSignature" nullable={true}>
+    <Type>
+      string
+    </Type>
+    <Description>
+      A signature of an adult is required
+    </Description>
+  </Field>
+  <Field name="DirectSignature" nullable={true}>
+    <Type>
+      string
+    </Type>
+    <Description>
+      Only supported by FedEx. The signature of somebody at the address is required
+    </Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/confirmation-type.mdx
+++ b/src/pages/docs/reference/confirmation-type.mdx
@@ -1,0 +1,26 @@
+---
+title: Confirmation Types
+description: This is a confirmation type
+---
+
+Confirmation Type
+===============================================
+This is a confirmation type
+
+<Reference>
+  <Field name="Name" type="string" nullable={false}>
+    <Description>
+      The text that should be displayed to users in the ui
+    </Description>
+  </Field>
+  <Field name="Type" type="string" nullable={false}>
+    <Description>
+      Options: <br />
+        - None
+        - Delivery
+        - Signature
+        - AdultSignature
+        - DirectSignature
+    </Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/label-formats-enum.mdx
+++ b/src/pages/docs/reference/label-formats-enum.mdx
@@ -1,0 +1,20 @@
+---
+title: Label Formats Enum
+description: These are the supported label formats by the carrier
+---
+
+# Label Formats Enum
+
+These are the supported label formats by the carrier
+
+<Reference>
+  <Field name="PDF">
+    <Description>This specifies that .pdf files are produced by the carrier</Description>
+  </Field>
+  <Field name="ZPL">
+    <Description>This specifies that .zpl files are produced by the carrier</Description>
+  </Field>
+  <Field name="PNG">
+    <Description>This specifies that .png files are produced by the carrier</Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/label-sizes-enum.mdx
+++ b/src/pages/docs/reference/label-sizes-enum.mdx
@@ -1,0 +1,17 @@
+---
+title: Label Sizes Enum
+description: These describe the supported label sizes
+---
+
+# Label Sizes Enum
+
+These describe the supported label sizes
+
+<Reference>
+  <Field name="Inches4x6">
+    <Description>This will be sent in requests as `label_layout: '4x6'`</Description>
+  </Field>
+  <Field name="Inches4x8">
+    <Description>This will be sent in requests as `label_layout: 'letter'`</Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -110,7 +110,10 @@ An object containing information about the new label to create.
     </Description>
   </Field>
 
-  <Field name="advanced_options" type="object" nullable={true}>
+  <Field name="advanced_options" nullable={true}>
+    <Type>
+      [AdvancedOptions](./../references/advanced-options.mdx)
+    </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.
       If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -112,7 +112,7 @@ An object containing information about the new label to create.
 
   <Field name="advanced_options" nullable={true}>
     <Type>
-      [AdvancedOptions](./../references/advanced-options.mdx)
+      [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.

--- a/src/pages/docs/reference/methods/create-manifest.mdx
+++ b/src/pages/docs/reference/methods/create-manifest.mdx
@@ -101,7 +101,10 @@ An object containing information about the labels to manifest.
     </Description>
   </Field>
 
-  <Field name="advanced_options" type="object" nullable={true}>
+  <Field name="advanced_options" nullable={true}>
+    <Type>
+      [AdvancedOptions](./../references/advanced-options.mdx)
+    </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.
       If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.

--- a/src/pages/docs/reference/methods/create-manifest.mdx
+++ b/src/pages/docs/reference/methods/create-manifest.mdx
@@ -103,7 +103,7 @@ An object containing information about the labels to manifest.
 
   <Field name="advanced_options" nullable={true}>
     <Type>
-      [AdvancedOptions](./../references/advanced-options.mdx)
+      [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.

--- a/src/pages/docs/reference/methods/get-rates.mdx
+++ b/src/pages/docs/reference/methods/get-rates.mdx
@@ -83,7 +83,7 @@ An object containing information about the shipment to get rates for. The more i
 
   <Field name="advanced_options" nullable={true}>
     <Type>
-      [AdvancedOptions](./../references/advanced-options.mdx)
+      [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.

--- a/src/pages/docs/reference/methods/get-rates.mdx
+++ b/src/pages/docs/reference/methods/get-rates.mdx
@@ -81,7 +81,10 @@ An object containing information about the shipment to get rates for. The more i
     </Description>
   </Field>
 
-  <Field name="advanced_options" type="object" nullable={true}>
+  <Field name="advanced_options" nullable={true}>
+    <Type>
+      [AdvancedOptions](./../references/advanced-options.mdx)
+    </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.
       If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.

--- a/src/pages/docs/reference/service-attributes-enum.mdx
+++ b/src/pages/docs/reference/service-attributes-enum.mdx
@@ -1,0 +1,44 @@
+---
+title: Service Attributes Enum
+description: This enum contains options for the service attributes supported by a carrier
+---
+
+# Service Attributes Enum
+
+This enum contains options for the service attributes supported by a carrier
+
+<Reference>
+  <Field name="Returns">
+    <Description></Description>
+  </Field>
+  <Field name="MultiPackage">
+    <Description></Description>
+  </Field>
+  <Field name="Tracking">
+    <Description>This attribute must be set in order for the Track() functionality to be called</Description>
+  </Field>
+  <Field name="ConsolidatorService">
+    <Description></Description>
+  </Field>
+  <Field name="AutomatedTrackingAllowed">
+    <Description></Description>
+  </Field>
+  <Field name="ManifestDigital">
+    <Description></Description>
+  </Field>
+  <Field name="ManifestPhysical">
+    <Description></Description>
+  </Field>
+  <Field name="SameDayService">
+    <Description></Description>
+  </Field>
+  <Field name="Tip">
+    <Description></Description>
+  </Field>
+  <Field name="DeliveryWindow">
+    <Description></Description>
+  </Field>
+  <Field name="PickupOnLabelCreation">
+    <Description></Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/service-class-enum.mdx
+++ b/src/pages/docs/reference/service-class-enum.mdx
@@ -1,0 +1,35 @@
+---
+title: Service Class Enum
+description: These are the services classes for a shipping service
+---
+
+# Service Class Enum
+
+These are the services classes for a shipping service
+
+<Reference>
+  <Field name="Unspecified">
+    <Description></Description>
+  </Field>
+  <Field name="Ground">
+    <Description></Description>
+  </Field>
+  <Field name="OneDay">
+    <Description></Description>
+  </Field>
+  <Field name="OneDayEarly">
+    <Description></Description>
+  </Field>
+  <Field name="OneDayEarlyAm">
+    <Description></Description>
+  </Field>
+  <Field name="TwoDay">
+    <Description></Description>
+  </Field>
+  <Field name="TwoDayEarly">
+    <Description></Description>
+  </Field>
+  <Field name="ThreeDay">
+    <Description></Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/service-grade-enum.mdx
+++ b/src/pages/docs/reference/service-grade-enum.mdx
@@ -1,0 +1,26 @@
+---
+title: Service Grade Enum
+description: These are the service grades for a given shipping service
+---
+
+# Service Grade Enum
+
+These are the service grades for a given shipping service
+
+<Reference>
+  <Field name="Unspecified">
+    <Description></Description>
+  </Field>
+  <Field name="Economy">
+    <Description></Description>
+  </Field>
+  <Field name="Expedited">
+    <Description></Description>
+  </Field>
+  <Field name="Overnight">
+    <Description></Description>
+  </Field>
+  <Field name="Standard">
+    <Description></Description>
+  </Field>
+</Reference>

--- a/src/pages/docs/reference/shipped-shipment.mdx
+++ b/src/pages/docs/reference/shipped-shipment.mdx
@@ -48,7 +48,10 @@ This model represents a shipment that has already been shipped, and contains sum
     </Description>
   </Field>
 
-  <Field name="advanced_options" type="object" nullable={true}>
+  <Field name="advanced_options" nullable={true}>
+    <Type>
+      [AdvancedOptions](./advanced-options.mdx)
+    </Type>
     <Description>
       This is a schemaless object. It is for open ended customizations unique to particular carriers.
       If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.


### PR DESCRIPTION
Joseph Killam compiled an awesome list of areas where our documentation was lacking on what the values could be for given fields. 

This PR should address the following:

## [Carrier App Definition](https://connect.shipengine.com/docs/app-definition/carrier) 

- DefaultConfirmationTypes (looks like there is a [page](https://connect.shipengine.com/docs/reference/common-types#delivery-confirmation-types) for this, just needs a link)

- LabelFormats

- DefaultLabelSizes

## ShippingServices

- SupportedLabelSizes

- ServiceAttributes

- ConfirmationTypes
- Class & Grade have a link “info” that leads to the private repo

## Auth

- Identifier.AuthenticationType

## [CreateLabel Method](https://connect.shipengine.com/docs/reference/methods/create-label) 

- advanced_options

## [CreateManifest Method](https://connect.shipengine.com/docs/reference/methods/create-manifest) 

- advanced_options

## [GetRates Method](https://connect.shipengine.com/docs/reference/methods/get-rates) 

- advanced_options