### PR TITLE
Update Advanced Options Wording

### DIFF
--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -115,7 +115,7 @@ An object containing information about the new label to create.
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdx) a user might select. 
     </Description>
   </Field>
 

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -115,8 +115,7 @@ An object containing information about the new label to create.
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This is a schemaless object. It is for open ended customizations unique to particular carriers.
-      If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
     </Description>
   </Field>
 

--- a/src/pages/docs/reference/methods/create-manifest.mdx
+++ b/src/pages/docs/reference/methods/create-manifest.mdx
@@ -106,7 +106,7 @@ An object containing information about the labels to manifest.
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdx) a user might select. 
     </Description>
   </Field>
 

--- a/src/pages/docs/reference/methods/create-manifest.mdx
+++ b/src/pages/docs/reference/methods/create-manifest.mdx
@@ -106,8 +106,7 @@ An object containing information about the labels to manifest.
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This is a schemaless object. It is for open ended customizations unique to particular carriers.
-      If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
     </Description>
   </Field>
 

--- a/src/pages/docs/reference/methods/get-rates.mdx
+++ b/src/pages/docs/reference/methods/get-rates.mdx
@@ -86,7 +86,7 @@ An object containing information about the shipment to get rates for. The more i
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdx) a user might select. 
     </Description>
   </Field>
   

--- a/src/pages/docs/reference/methods/get-rates.mdx
+++ b/src/pages/docs/reference/methods/get-rates.mdx
@@ -86,8 +86,7 @@ An object containing information about the shipment to get rates for. The more i
       [AdvancedOptions](./../advanced-options.mdx)
     </Type>
     <Description>
-      This is a schemaless object. It is for open ended customizations unique to particular carriers.
-      If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.
+      This contains an optional set of properties describing the advanced [options](./../advanced-options.mdxadvanced-options.mdx) a user might select. 
     </Description>
   </Field>
   

--- a/src/pages/docs/reference/shipped-shipment.mdx
+++ b/src/pages/docs/reference/shipped-shipment.mdx
@@ -53,8 +53,7 @@ This model represents a shipment that has already been shipped, and contains sum
       [AdvancedOptions](./advanced-options.mdx)
     </Type>
     <Description>
-      This is a schemaless object. It is for open ended customizations unique to particular carriers.
-      If the field is absent it should be interpreted as the default value for any applicable options, e.g. false for booleans.
+      This contains an optional set of properties describing the advanced [options](./advanced-options.mdx) a user might select. 
     </Description>
   </Field>
 


### PR DESCRIPTION
The old wording was for internal developers but was confusing to external devs.