### PR TITLE
CHORE: rewrote the descriptions of two PUDO fields to hopefully clarify the difference between the two.

### DIFF
--- a/src/layouts/docs/menu-contents.ts
+++ b/src/layouts/docs/menu-contents.ts
@@ -73,7 +73,7 @@ export const menu: MenuContents = [
           { title: "Get Rates", href: "/docs/reference/methods/get-rates" },
           { title: "Track", href: "/docs/reference/methods/track" },
           {
-            title: "GetRelayPoints",
+            title: "Get Relay Points",
             href: "/docs/reference/methods/get-relay-points",
           },
         ],
@@ -120,11 +120,11 @@ export const menu: MenuContents = [
             href: "/docs/reference/pickup-confirmation",
           },
           {
-            title: "OpeningTimes",
+            title: "Opening Times",
             href: "/docs/reference/opening-times",
           },
           {
-            title: "RelayPointAddress",
+            title: "Relay Point Address",
             href: "/docs/reference/relay-point-address",
           },
         ],

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -177,13 +177,19 @@ An object containing information about the new label to create.
       [pickup location object](./../carrier-address.mdx#pickup-location-object)
     </Type>
     <Description>
-      If this is a pickup shipment, a pickup location will be populated for where the recipient can pickup the shipment.
+      Some carriers allow for a pickup location to be specified that differs from the `ship_from` location.
+      If the carrier supports pickup locations and this field is populated, this will be the actual origin of the shipment and the `ship_from` field will be what appears on the label.
+
+      > **Note:** Pickup location differs from `relay_points` by allowing for any arbitrary address instead of `relay_points` official carrier locations.
     </Description>
   </Field>
 
   <Field name="relay_points" type="object" nullable={true}>
     <Description>
-      If this is a shipment that uses relay points, this will show which relay points to ship from and to.
+      Some carriers allow for shipments to be sent from and delivered to carrier official locations named relay points. These official locations could be lockers or a third party business that hold packages for the carrier.
+      If this is a shipment that uses relay points, this field will show which relay points to ship from and to.
+
+      > **Note:** Relay points differs from `pickup_location` by only allowing carrier official locations returned through the [Get Relay Points](./get-relay-points.mdx) method.
     </Description>
   </Field>
 
@@ -264,7 +270,6 @@ An object containing information about the new label to create.
   </Field>
 
 </Reference>
-
 
 
 Return Value

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -178,18 +178,20 @@ An object containing information about the new label to create.
     </Type>
     <Description>
       Some carriers allow for a pickup location to be specified that differs from the `ship_from` location.
+      
       If the carrier supports pickup locations and this field is populated, this will be the actual origin of the shipment and the `ship_from` field will be what appears on the label.
 
-      > **Note:** Pickup location differs from `relay_points` by allowing for any arbitrary address instead of `relay_points` official carrier locations.
+      - **Note:** Pickup location differs from `relay_points` by allowing for any arbitrary address instead of `relay_points` official carrier locations.
     </Description>
   </Field>
 
   <Field name="relay_points" type="object" nullable={true}>
     <Description>
       Some carriers allow for shipments to be sent from and delivered to carrier official locations named relay points. These official locations could be lockers or a third party business that hold packages for the carrier.
+      
       If this is a shipment that uses relay points, this field will show which relay points to ship from and to.
 
-      > **Note:** Relay points differs from `pickup_location` by only allowing carrier official locations returned through the [Get Relay Points](./get-relay-points.mdx) method.
+      - **Note:** Relay points differs from `pickup_location` by only allowing carrier official locations returned through the [Get Relay Points](./get-relay-points.mdx) method.
     </Description>
   </Field>
 

--- a/src/pages/docs/reference/methods/create-label.mdx
+++ b/src/pages/docs/reference/methods/create-label.mdx
@@ -187,11 +187,11 @@ An object containing information about the new label to create.
 
   <Field name="relay_points" type="object" nullable={true}>
     <Description>
-      Some carriers allow for shipments to be sent from and delivered to carrier official locations named relay points. These official locations could be lockers or a third party business that hold packages for the carrier.
+      Some carriers allow for shipments to be sent from and delivered to carrier official locations named relay points. These official locations might be lockers or a third party business that holds packages for the carrier.
       
       If this is a shipment that uses relay points, this field will show which relay points to ship from and to.
 
-      - **Note:** Relay points differs from `pickup_location` by only allowing carrier official locations returned through the [Get Relay Points](./get-relay-points.mdx) method.
+      - **Note:** Relay points differ from `pickup_location` by only allowing carrier official locations returned through the [Get Relay Points](./get-relay-points.mdx) method.
     </Description>
   </Field>
 


### PR DESCRIPTION
Rewrote `pickup_location` and `relay_points` on the create label page to hopefully clarify when one is used vs the other.

Also added some spaces to the menu entries for the relay points pages so they match the other entries.