### PR TITLE
Remove Template Text From FAQ and Contact Page

### DIFF
--- a/contact.mdx
+++ b/contact.mdx
@@ -2,17 +2,5 @@
 title: Contact Us
 ---
 
-import { Flex, WideTile  } from '@redocly/developer-portal/ui';
-
 # Contact us
-
-You may reach us by email, team [at] redoc [dot] ly. (replace the at and the dot with the appropriate characters)
-
-**Use React components here, too!**
-
-<Flex justifyContent="space-between">
-  <WideTile to="https://google.com" title="Can't find your answer?">
-    Google it! <br/>
-    Use Google to find things.
-  </WideTile>
-</Flex>
+## Coming Soon

--- a/faq.md
+++ b/faq.md
@@ -4,12 +4,4 @@ title: F.A.Q.
 
 # Frequently asked questions
 
-## How much does it cost?
-
-https://preview.redoc.ly/redocly/new-site/pricing
-
-
-## Can I do ______?
-
-Please contact us.
-
+## Coming Soon


### PR DESCRIPTION
Just removing the boilerplate text, we will eventually want to add real text examples. Also using this as an opportunity to test and make sure the vercel stuff doesn't proc again.