### PR TITLE
Publish the v1 site using Github Pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,46 @@
+name: V1 GitHub Pages
+
+on:
+  push:
+    branches:
+      - v1
+  pull_request:
+    branches:
+      - v1
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install node@14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: install dependencies
+        run: yarn install --immutable --immutable-cache
+
+      - name: test
+        run: yarn run lint
+
+      - name: build
+        run: yarn run build
+
+      - name: next.js export
+        run: yarn run export
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/v1' }}
+        with:
+          cname: connect-v1.shipengine.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages-v1
+          publish_dir: ./out

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ShipEngine Connect Website
 ==============================================
 
-This repo is the public website for [ShipEngine Connect](https://connect.shipengine.com/), including its documentation.
+This repo is the public website for [ShipEngine Connect v1](https://connect-v1.shipengine.com/), including its documentation.
 
 This is a [Next.js](https://nextjs.org/) application, and it uses [MDX](https://github.com/mdx-js/mdx) for the documentation pages.
 
@@ -50,10 +50,8 @@ yarn upgrade
 
 
 ### QA / Review
-We use [Vercel](https://vercel.com/) to host the ShipEngine Connect website. One of the nice features of Vercel is that it creates a preview URL for every Git branch and PR, so you can see how the site will look in production and share the link with others to review .
-
-Just push your changes to your branch/PR and then go to [the Vercel dashboard](https://vercel.com/shipengine) to monitor the build process and get your preview URL.
+We use [Github Pages](https://pages.github.com/) to host the ShipEngine Connect v1 website. There is not currently a live preview associated with pull requests. Please test your changes locally and include screenshots in your pull request description when appropriate.
 
 
 ### Releasing to Prod
-Once you've reviewed your changes on the preview website and are happy with them, releasing to production is just a matter of merging to `master` and pushing.  Vercel will automatically deploy the site to [connect.shipengine.com](https://connect.shipengine.com).
+Once you've reviewed your changes on the preview website and are happy with them, releasing to production is just a matter of merging to `v1` and pushing.  Github will automatically deploy the site to [connect-v1.shipengine.com](https://connect-v1.shipengine.com).

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextMDX = require("@jsdevtools/next-mdx");
 const withMDX = nextMDX({
   layoutsDir: "./src/layouts",
   pagesDir: "./src/pages",
-  siteURL: "https://connect.shipengine.com",
+  siteURL: "https://connect-v1.shipengine.com",
 });
 
 // Enable MDX in Next.js

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "next dev -p 3005",
     "build": "next build",
+    "export": "next export",
     "start": "next start",
     "lint": "eslint src --ext=.ts,.tsx"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@shipengine/connect-website",
   "version": "1.0.0",
   "description": "The ShipEngine Connect website, including documentation",
-  "homepage": "https://connect.shipengine.com/",
+  "homepage": "https://connect-v1.shipengine.com/",
   "repository": {
     "type": "git",
     "url": "https://github.com/ShipEngine/connect.git"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Sitemap: https://connect.shipengine.com/sitemap.xml
+Sitemap: https://connect-v1.shipengine.com/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -2,7 +2,7 @@
   "name": "ShipEngine Connect",
   "short_name": "Connect",
   "description": "Integrate your carrier or marketplace with our world class e-commerce solutions and gain immediate access to a global user base",
-  "start_url": "https://connect.shipengine.com/",
+  "start_url": "https://connect-v1.shipengine.com/",
   "theme_color": "#FFFFFF",
   "background_color": "#FFFFFF",
   "display": "standalone",

--- a/src/layouts/page/header.tsx
+++ b/src/layouts/page/header.tsx
@@ -18,7 +18,7 @@ export function Header() {
         </label>
         <input id="site-search" className="st-default-search-input"
           name="q" type="search" placeholder="Search" />
-        <input type="hidden" name="as_sitesearch" value="connect.shipengine.com" />
+        <input type="hidden" name="as_sitesearch" value="connect-v1.shipengine.com" />
       </form>
     </header>
   );

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -4,7 +4,7 @@ import { isDev } from "./utils";
 /**
  * The URL of the ShipEngine Connect website
  */
-export const siteURL = new URL(isDev ? "http://localhost:3000" : "https://connect.shipengine.com");
+export const siteURL = new URL(isDev ? "http://localhost:3000" : "https://connect-v1.shipengine.com");
 
 /**
  * The ShipEngine Connect logo image URL
@@ -20,5 +20,5 @@ export const defaultImageURL = new URL("img/media/card-square.png", siteURL);
  * Returns the canonical URL of the current page
  */
 export function getPageURL(router: NextRouter): URL {
-  return new URL(router.pathname, siteURL);
+    return new URL(router.pathname, siteURL);
 }

--- a/src/pages/docs/contributing.mdx
+++ b/src/pages/docs/contributing.mdx
@@ -15,9 +15,9 @@ When contributing a Connect app to the ShipEngine Connect platform, please follo
 
 ## Getting started
 
-1. To get started with Connect, follow the [online documentation to create a new app](https://connect.shipengine.com/docs/cli#initialize-a-new-app). 
+1. To get started with Connect, follow the [online documentation to create a new app](https://connect-v1.shipengine.com/docs/cli#initialize-a-new-app).
 
-2. Once you have [installed the Connect npm package](https://connect.shipengine.com/docs/cli) => `npm i @shipengine/connect -g`, you will be able to generate a new templated base repository via the cli => `connect init`.
+2. Once you have [installed the Connect npm package](https://connect-v1.shipengine.com/docs/cli) => `npm i @shipengine/connect -g`, you will be able to generate a new templated base repository via the cli => `connect init`.
 
 3. As a best practice to help ensure that visibility is clear for any changes made after the template has been scaffolded on your local machine, we ask that you create an initial commit before adding any custom changes.
 
@@ -41,7 +41,7 @@ When contributing a Connect app to the ShipEngine Connect platform, please follo
 
 ### General guidance
 
-1. The documentation site can be found here, http://connect.shipengine.com/. This is the best single resource to answer your questions related to building a Connect app. Please familiarize yourself with these docs.
+1. The documentation site can be found here, http://connect-v1.shipengine.com/. This is the best single resource to answer your questions related to building a Connect app. Please familiarize yourself with these docs.
    - It will be helpful to review the [Sample Apps](https://github.com/ShipEngine/connect-samples) as well to get a grasp on how implementation can be handled in a few example scenarios.
 2. Do not use non-public shared packages, as they will fail to build and deploy properly inside our production environments.
    - If a package is **not** publicly hosted and available via `npm`, it should be not referenced as a dependency within your app.
@@ -55,25 +55,25 @@ When contributing a Connect app to the ShipEngine Connect platform, please follo
 
 ### Expectations for contractors
 
-1. Deliver a functional application that fulfills the outlined requirements within an established timeframe. 
+1. Deliver a functional application that fulfills the outlined requirements within an established timeframe.
 2. As development progresses, status updates and communication of any barriers should happen without delay so they can be addressed in a timely manner.
 3. Clear communication is essential to delivering a high quality integration and should be done throughout the process.
 4. Feedback on how the offering can be improved to facilitate better development should be a primary consideration.
 
 ### When the docs are not enough
 
-1. When questions arise which are not addressed within the documentation, they should be directed to the Engineering Coordinators to effectively answer the questions and work with the team to update the Connect SDK and/or documentation to clarify the situation. 
+1. When questions arise which are not addressed within the documentation, they should be directed to the Engineering Coordinators to effectively answer the questions and work with the team to update the Connect SDK and/or documentation to clarify the situation.
 2. Likewise, when there are features or elements that are supported within a Carrier or Order Source which do not correlate with any available methods in ShipEngine Connect, we would like to be made aware of them so that we can investigate and potentially fill the noted gaps in supported functionality.
 
 ### Code quality
 
 1. **Security is paramount**. As such there is a lot of time and thought that should be taken to ensure both the code as well as the process is secure. Listed below are some common considerations that should be taken to help ensure security gaps are considered and mitigated during the development phase.
    - Never store credentials inside the git repository.
-   
+
    - Frequently `client_id` and `client_secret`'s are needed to allow an integration to authenticate with 3rd party apis. The secret should always remain secret.
      - When you have the option... You should not pass secrets as part of a URL. If the API you are calling requires this, you may not have a choice. But if you have an option to send via the headers, you should choose the header option.
        - Note that when using HTTPS, even the query string will be protected, but the path is likely to still end up inside the logs.
-   
+
 2. Audit your commit history to ensure you have not committed sensitive data into the version control history.
 
    - `git grep SENSITIVE_DATA_STRING_HERE $(git rev-list --all)`

--- a/src/pages/docs/create-first-app.mdx
+++ b/src/pages/docs/create-first-app.mdx
@@ -71,7 +71,7 @@ specifies the path to a file that exports the method, the structure is up to you
  * Generates a shipping label and tracking number for a shipment
  *
  * View documentation here:
- * https://connect.shipengine.com/docs/reference/methods/create-shipment
+ * https://connect-v1.shipengine.com/docs/reference/methods/create-shipment
  *
  * View sample implementation here:
  * https://github.com/ShipEngine/connect-samples/blob/master/freightco/carrier/create-shipment.js


### PR DESCRIPTION
Since we've moved from [vercel](https://vercel.com/) to [redocly](https://redocly.com/enterprise/) on the [main branch](https://github.com/ShipEngine/connect-website/tree/main/).