### PR TITLE
Add Metadata Definition For Carriers

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -46,7 +46,7 @@ export default LandingLayout;
     <ThinTile header="Orders" icon={orderIcon} to="./orders/index.mdx">
         Import Orders, Notify Marketplaces, etc...
     </ThinTile>
-    <ThinTile header="Shipping" icon={packageIcon} to="./shipping/index.md">
+    <ThinTile header="Shipping" icon={packageIcon} to="./shipping/index.mdx">
         Get Rates, Create Labels, Tracking, etc...
     </ThinTile>
     <ThinTile header="Inventory" icon={cogBrowser} >

--- a/shipping/index.md
+++ b/shipping/index.md
@@ -1,4 +1,0 @@
----
-title: Shipping
----
-# Shipping

--- a/shipping/index.mdx
+++ b/shipping/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Shipping
+---
+# Shipping
+import { JsonSchema } from "@redocly/developer-portal/ui";
+import Schema from "./metadata-schema.json";
+
+## Metadata Definition
+<JsonSchema
+  schema={Schema}
+/>
+
+:::success OAuth
+Learn More about defining an OAuth AuthProcess [here](../oauth/index.md)
+:::

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1,0 +1,1515 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "description": "The metadata describing the carrier integration",
+  "properties": {
+    "Id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "The id for this integration **(this GUID should not be changed after publishing)**"
+    },
+    "Name": {
+      "type": "string",
+      "description": "The name of this integration, used for internal purposes, can be the same as the branded Carrier in Carriers[]"
+    },
+    "AuthProcess": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The specification for authorizing with this carrier. Only specify if using OAuth",
+      "properties": {
+        "Identifier": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Identify the type of Auth being used by the integration",
+          "properties": {
+            "AuthenticationType": {
+              "type": "string",
+              "enum": [
+                "oauth"
+              ],
+              "description": "Identify the type of Auth being used by the integration"
+            },
+            "IsSandbox": {
+              "type": "boolean",
+              "description": "Indicates whether or not the authentication server is sandboxed"
+            }
+          },
+          "required": [
+            "AuthenticationType"
+          ]
+        },
+        "access_token": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Added to allow oauth 1.0 to work",
+          "properties": {
+            "url_template": {
+              "type": "string",
+              "description": "The url to obtain the temporary Access (aka Request) Token to start a flow"
+            }
+          },
+          "required": [
+            "url_template"
+          ]
+        },
+        "authorization": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Authorization: the beginning of an OAuth2.0 flow that ensures the user is logged in and approves access to the Resource",
+          "properties": {
+            "url_template": {
+              "type": "string",
+              "description": "The url to obtain the access token using the authorization code on the backend `https://carrier.com/oauth/authorize`",
+              "example": "\"http://{auth_state:store_name}.store.com/admin/oauth/authorize\", \"http://store.com/oauth/authorize\""
+            },
+            "query_parameters": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "DELETE",
+                "PUT",
+                "get",
+                "post",
+                "delete",
+                "put"
+              ],
+              "description": "The http method to use when making the server-server code for token request `GET`, `POST`"
+            },
+            "body": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "headers": {
+              "type": "array",
+              "description": "A list of header values that will be sent to request the token",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "nonce": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "A nonce query parameter included on the accept request, then returned and validated on the redirect request"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "required": [
+            "url_template"
+          ]
+        },
+        "request_token": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "url_template": {
+              "type": "string",
+              "description": "The url to obtain the access token using the authorization code on the backend `https://carrier.com/oauth/authorize`",
+              "example": "\"http://{auth_state:store_name}.store.com/admin/oauth/authorize\", \"http://store.com/oauth/authorize\""
+            },
+            "query_parameters": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "DELETE",
+                "PUT",
+                "get",
+                "post",
+                "delete",
+                "put"
+              ],
+              "description": "The http method to use when making the server-server code for token request `GET`, `POST`"
+            },
+            "body": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "headers": {
+              "type": "array",
+              "description": "A list of header values that will be sent to request the token",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "nonce": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "A nonce query parameter included on the accept request, then returned and validated on the redirect request"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "response": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Response payload parsing",
+              "properties": {
+                "access_token": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for access_token"
+                },
+                "token_type": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for token_type"
+                },
+                "refresh_token": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for refresh_token"
+                },
+                "expires_in": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for expires_in. Mutually exclusive with expires_at"
+                },
+                "expires_at": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Configuration for parsing a date-time, when the integration is lacking expires_in",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "JSONPath to the JSON element containing the date-time"
+                    },
+                    "date_time_format": {
+                      "type": "string",
+                      "description": "DateTime format string compliant with [Microsoft Datetime Format String](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings)"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "date_time_format"
+                  ]
+                },
+                "connection_context": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Optional collection of properties to include in the connection_context sent back with the auth flow result"
+                }
+              },
+              "required": [
+                "access_token",
+                "token_type"
+              ]
+            }
+          },
+          "required": [
+            "url_template"
+          ],
+          "description": "Request Token: server-server code for token exchange"
+        },
+        "refresh_token": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "url_template": {
+              "type": "string",
+              "description": "The url to obtain the access token using the authorization code on the backend `https://carrier.com/oauth/authorize`",
+              "example": "\"http://{auth_state:store_name}.store.com/admin/oauth/authorize\", \"http://store.com/oauth/authorize\""
+            },
+            "query_parameters": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "DELETE",
+                "PUT",
+                "get",
+                "post",
+                "delete",
+                "put"
+              ],
+              "description": "The http method to use when making the server-server code for token request `GET`, `POST`"
+            },
+            "body": {
+              "type": "array",
+              "description": "A list of query parameters that will be attached to the url",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "headers": {
+              "type": "array",
+              "description": "A list of header values that will be sent to request the token",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the parameter"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value associated with the parameter"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "nonce": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "A nonce query parameter included on the accept request, then returned and validated on the redirect request"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "response": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Response payload parsing",
+              "properties": {
+                "access_token": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for access_token"
+                },
+                "token_type": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for token_type"
+                },
+                "refresh_token": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for refresh_token"
+                },
+                "expires_in": {
+                  "type": "string",
+                  "description": "JSONPath to the JSON element for expires_in. Mutually exclusive with expires_at"
+                },
+                "expires_at": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Configuration for parsing a date-time, when the integration is lacking expires_in",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "JSONPath to the JSON element containing the date-time"
+                    },
+                    "date_time_format": {
+                      "type": "string",
+                      "description": "DateTime format string compliant with [Microsoft Datetime Format String](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings)"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "date_time_format"
+                  ]
+                },
+                "connection_context": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Optional collection of properties to include in the connection_context sent back with the auth flow result"
+                }
+              },
+              "required": [
+                "access_token",
+                "token_type"
+              ]
+            }
+          },
+          "required": [
+            "url_template"
+          ],
+          "description": "Refresh Token: server-server refresh token exchange for access token **NOTE: sometimes a new RT is also created**"
+        },
+        "advanced_configuration": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": ""
+              },
+              "value": {
+                "type": "string",
+                "description": ""
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ]
+          },
+          "description": "Advanced configurations used for oauth 1.0"
+        }
+      }
+    },
+    "Carriers": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "description": "A list of branded carriers",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "AccountModals": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "RegistrationFormSchema",
+              "SettingsFormSchema"
+            ],
+            "description": "This defines the connection modal and the settings modals in the ui, along with branded images",
+            "properties": {
+              "RegistrationFormSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "JsonSchema",
+                  "UiSchema"
+                ],
+                "description": "A form that allows the user to connect to the service. This form will usually prompt for an account number and login credentials",
+                "properties": {
+                  "JsonSchema": {
+                    "type": "object",
+                    "description": ""
+                  },
+                  "UiSchema": {
+                    "type": "object",
+                    "description": ""
+                  }
+                }
+              },
+              "SettingsFormSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "JsonSchema",
+                  "UiSchema"
+                ],
+                "description": "A form that allows the user update their connection settings, such as when a password is changed",
+                "properties": {
+                  "JsonSchema": {
+                    "type": "object",
+                    "description": ""
+                  },
+                  "UiSchema": {
+                    "type": "object",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          },
+          "PackageTypes": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "A list of package types associated with this branded carrier",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "Id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The unique identifier for this package type. **It should not change after being published**"
+                },
+                "Name": {
+                  "type": "string",
+                  "maxLength": 50,
+                  "description": "The name of this package type ex: `'Eco friendly box'`"
+                },
+                "ApiCode": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_]*[a-z]$",
+                  "description": "The identifier for this package type to be used in API calls. Must be snake cased and unique."
+                },
+                "CarrierPackageTypeCode": {
+                  "type": "string",
+                  "maxLength": 50,
+                  "description": "This is the code that will be sent to requests, this should be the same code the carrier's api would expect"
+                },
+                "Description": {
+                  "type": "string",
+                  "maxLength": 500,
+                  "description": "This is a human readable description about what the packaging is"
+                },
+                "Abbreviation": {
+                  "type": "string",
+                  "maxLength": 20,
+                  "description": "This is an abbreviation of the name if necessary"
+                },
+                "PackageAttributes": {
+                  "type": "array",
+                  "description": "Package attributes",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "International",
+                      "Domestic",
+                      "Consolidator"
+                    ]
+                  }
+                },
+                "RequiredToShip": {
+                  "type": "array",
+                  "description": "What information is required to ship this package type",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Weight",
+                      "Dimensions"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "Id",
+                "Name",
+                "CarrierPackageTypeCode",
+                "PackageAttributes"
+              ]
+            }
+          },
+          "ShippingServices": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ConfirmationTypes": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "Name": {
+                        "type": "string",
+                        "maxLength": 50,
+                        "description": ""
+                      },
+                      "Type": {
+                        "type": "string",
+                        "enum": [
+                          "None",
+                          "Delivery",
+                          "Signature",
+                          "AdultSignature",
+                          "DirectSignature"
+                        ],
+                        "description": ""
+                      }
+                    }
+                  },
+                  "description": "The confirmation types associated with this service"
+                },
+                "ServiceAttributes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Returns",
+                      "MultiPackage",
+                      "Tracking",
+                      "ConsolidatorService",
+                      "AutomatedTrackingAllowed",
+                      "ManifestDigital",
+                      "ManifestPhysical",
+                      "SameDayService",
+                      "Tip",
+                      "DeliveryWindow",
+                      "PickupOnLabelCreation"
+                    ]
+                  },
+                  "description": "A list of attributes about this service"
+                },
+                "SupportedCountries": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "FromCountry": {
+                        "type": "string",
+                        "description": ""
+                      },
+                      "AlternateServiceName": {
+                        "type": "string",
+                        "description": ""
+                      }
+                    },
+                    "required": [
+                      "FromCountry"
+                    ]
+                  },
+                  "description": "A list of countries supported by this service"
+                },
+                "SupportedLabelSizes": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Inches4x6",
+                      "Inches4x8"
+                    ]
+                  },
+                  "description": "A list of label sizes supported by this service"
+                },
+                "RequiredProperties": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Weight",
+                      "Dimensions"
+                    ]
+                  }
+                },
+                "Grade": {
+                  "type": "string",
+                  "enum": [
+                    "Unspecified",
+                    "Economy",
+                    "Expedited",
+                    "Overnight",
+                    "Standard"
+                  ],
+                  "description": "The grade of the service"
+                },
+                "Class": {
+                  "type": "string",
+                  "enum": [
+                    "Unspecified",
+                    "Ground",
+                    "OneDay",
+                    "OneDayEarly",
+                    "OneDayEarlyAm",
+                    "TwoDay",
+                    "TwoDayEarly",
+                    "ThreeDay"
+                  ],
+                  "description": "The class of service"
+                },
+                "LabelCode": {
+                  "type": "string",
+                  "maxLength": 50,
+                  "description": "The label code associated with this shipping service"
+                },
+                "International": {
+                  "type": "boolean",
+                  "description": "Indicates whether or not this service is for international or domestic use"
+                },
+                "Code": {
+                  "type": "string",
+                  "maxLength": 50,
+                  "description": "This is the code that will be sent to requests, this should be the same code the carrier's api would expect"
+                },
+                "Abbreviation": {
+                  "type": "string",
+                  "maxLength": 20,
+                  "description": "This is an abbreviation of the name if necessary"
+                },
+                "Name": {
+                  "type": "string",
+                  "maxLength": 80,
+                  "description": "The name of this shipping service ex: `'Overnight Guarantee'`"
+                },
+                "ApiCode": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_]*[a-z]$",
+                  "description": "The identifier for this shipping service to be used in API calls. Must be snake cased and unique"
+                },
+                "Id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The unique identifier for this shipping service. **It should not change after being published**"
+                }
+              },
+              "required": [
+                "Code",
+                "Name",
+                "Id"
+              ]
+            },
+            "description": "A list of shipping services associated with this branded carrier"
+          },
+          "ShippingOptions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "alcohol": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": "This object defines which shipping options should be made available and what those shipping options should be called in the ui"
+              },
+              "b13a-canada": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "bill-to-sender": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "bill-to-third-party": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "collect-on-delivery": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "consequential-loss": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "dangerous-goods": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "delivery-message": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "dont-prepay-postage": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "dry-ice": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "email-notification": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "freight-class": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "hold-for-pickup": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "include-return-label": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "local-collect": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "non-machinable": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "notification-type": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "shipper-release": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "additional-handling": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "safeplace": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "saturday-delivery": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "saturday-guarantee": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "sms-notification": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "special-handling": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "third-party-consignee": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              },
+              "carrier-insurance": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              }
+            },
+            "description": ""
+          },
+          "DefaultSupportedCountries": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "FromCountry": {
+                  "type": "string",
+                  "description": "The 2 character ISO country code ex: `US`, `MX`, `FR`"
+                },
+                "AlternateServiceName": {
+                  "type": "string",
+                  "description": "An optional name for this service based on the countries branding"
+                }
+              },
+              "required": [
+                "FromCountry"
+              ]
+            },
+            "description": "A list of supported countries, used to determine which services are visible based on shipstation sellers home country"
+          },
+          "DefaultLabelSizes": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Inches4x6",
+                "Inches4x8"
+              ]
+            },
+            "description": "This provides a list of supported label sizes by the carrier"
+          },
+          "LabelFormats": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "PDF",
+                "ZPL",
+                "PNG"
+              ]
+            },
+            "description": "This provides a list of label formats supported by the carrier"
+          },
+          "DefaultConfirmationTypes": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "None": {
+                "type": "string",
+                "description": ""
+              },
+              "Delivery": {
+                "type": "string",
+                "description": ""
+              },
+              "Signature": {
+                "type": "string",
+                "description": ""
+              },
+              "AdultSignature": {
+                "type": "string",
+                "description": ""
+              },
+              "DirectSignature": {
+                "type": "string",
+                "description": ""
+              }
+            },
+            "description": "This dictionary allows you to specify which supported delivery confirmation types the carrier offers. Setting one to undefined will use the default name in shipstation"
+          },
+          "CarrierAttributes": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "ManifestDigital",
+                "ManifestPhysical",
+                "Consolidator",
+                "Regional"
+              ]
+            },
+            "description": "Attributes describing the carrier"
+          },
+          "TrackingUrl": {
+            "type": "string",
+            "pattern": "^((http|https):\\/\\/)([^\\/\\s]+)\\.([^(.:)\\/\\s]+)((\\/\\w+)*\\/?)([\\w\\-\\.]+[^#?\\s]+)(.*)?(#[\\w\\-]+)?$",
+            "description": "This is the url template for static tracking pages ex: `http://www.shipper.com/tracking/{0}`"
+          },
+          "CarrierUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 200,
+            "description": "This is the url to the carriers website"
+          },
+          "Description": {
+            "type": "string",
+            "maxLength": 250,
+            "description": "This is a human readable description of the branded carrier"
+          },
+          "Name": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "The name of this branded carrier, this is what is seen by the customer"
+          },
+          "ApiCode": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*[a-z]$",
+            "description": "The identifier for this carrier to be used in API calls. Must be snake cased and unique"
+          },
+          "Id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id for this branded carrier **(this GUID should not be changed after publishing)**"
+          },
+          "Images": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "Icon",
+              "Logo"
+            ],
+            "properties": {
+              "Icon": {
+                "type": "string",
+                "pattern": "^.*.(svg)$",
+                "description": "This is the full file path to the branded icon"
+              },
+              "Logo": {
+                "type": "string",
+                "pattern": "^.*.(svg)$",
+                "description": "This is the full file path to the branded logo"
+              }
+            },
+            "description": "This defines a list of images associated with this branded carrier"
+          },
+          "RequiresLabelPayment": {
+            "type": "boolean",
+            "description": "Indicates whether the carrier requires the label be purchased on calling create label"
+          }
+        },
+        "required": [
+          "AccountModals",
+          "Name",
+          "Id",
+          "Images"
+        ]
+      }
+    }
+  },
+  "required": [
+    "Id",
+    "Name",
+    "Carriers"
+  ]
+}

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -17,7 +17,7 @@ gettingStarted:
       - page: getting-started/publishing.md
         label: Publish Your App
 shipping:
-  - page: shipping/index.md
+  - page: shipping/index.mdx
   - group: Methods
     expanded: true
     pages:


### PR DESCRIPTION
We were missing the metadata definition that we had for order sources for carriers. This adds the json schema for carrier metadata.