### PR TITLE
Add CustomFieldOptions to OrderSource metadata

### DIFF
--- a/orders/metadata-schema.json
+++ b/orders/metadata-schema.json
@@ -504,6 +504,7 @@
                 "DisplayName"
               ],
               "additionalProperties": false
+            }
           },
           "CanLeaveFeedback": {
             "description": "Indicates whether or not the order source allows sellers to leave feedback on customers",

--- a/orders/metadata-schema.json
+++ b/orders/metadata-schema.json
@@ -478,7 +478,6 @@
             "description": "This tells the UI which options are available for custom fields",
             "type": "array",
             "uniqueItems": true,
-            "optional": true,
             "items": {
               "description": "A Custom Field Option describes a possible value that a store could send as a `sales_order_field_mapping` during `sales_orders_export` requests",
               "type": "object",
@@ -493,16 +492,18 @@
                 },
                 "IsAdmin": {
                   "description": "Set to true if this option must be enabled by support",
-                  "type": "boolean",
-                  "optional": "true"
+                  "type": "boolean"
                 },
                 "IsDeprecated": {
                   "description": "Set to true if this option shouldn't be shown in the UI. This does not prevent the option from being sent to the API for stores which have already chosen it.",
-                  "type": "boolean",
-                  "optional": "true"
+                  "type": "boolean"
                 }
-              }
-            }
+              },
+              "required": [
+                "Field",
+                "DisplayName"
+              ],
+              "additionalProperties": false
           },
           "CanLeaveFeedback": {
             "description": "Indicates whether or not the order source allows sellers to leave feedback on customers",
@@ -603,7 +604,6 @@
           "Id",
           "Name",
           "SendEmail",
-          "HasCustomMappings",
           "CanLeaveFeedback",
           "CanConfigureTimeZone",
           "AccountConnection",

--- a/orders/metadata-schema.json
+++ b/orders/metadata-schema.json
@@ -471,8 +471,38 @@
             "type": "boolean"
           },
           "HasCustomMappings": {
-            "description": "Indicates whether or not this marketplace allows custom mappings",
+            "description": "This field is deprecated, supply CustomFieldOptions instead.",
             "type": "boolean"
+          },
+          "CustomFieldOptions": {
+            "description": "This tells the UI which options are available for custom fields",
+            "type": "array",
+            "uniqueItems": true,
+            "optional": true,
+            "items": {
+              "description": "A Custom Field Option describes a possible value that a store could send as a `sales_order_field_mapping` during `sales_orders_export` requests",
+              "type": "object",
+              "properties": {
+                "Field": {
+                  "description": "The name of the field being requested, which will be sent as`custom_field_*` when chosen by the seller. This value is expected to be unique per integration.",
+                  "type": "string"
+                },
+                "DisplayName": {
+                  "description": "The name of this option to use in the UI",
+                  "type": "string"
+                },
+                "IsAdmin": {
+                  "description": "Set to true if this option must be enabled by support",
+                  "type": "boolean",
+                  "optional": "true"
+                },
+                "IsDeprecated": {
+                  "description": "Set to true if this option shouldn't be shown in the UI. This does not prevent the option from being sent to the API for stores which have already chosen it.",
+                  "type": "boolean",
+                  "optional": "true"
+                }
+              }
+            }
           },
           "CanLeaveFeedback": {
             "description": "Indicates whether or not the order source allows sellers to leave feedback on customers",

--- a/orders/metadata-schema.json
+++ b/orders/metadata-schema.json
@@ -475,15 +475,14 @@
             "type": "boolean"
           },
           "CustomFieldOptions": {
-            "description": "This tells the UI which options are available for custom fields",
+            "description": "A Custom Field Option describes a possible value that a store could send as a `sales_order_field_mapping` during `sales_orders_export` requests. These options will be used by the UI to populate settings forms automatically.",
             "type": "array",
             "uniqueItems": true,
             "items": {
-              "description": "A Custom Field Option describes a possible value that a store could send as a `sales_order_field_mapping` during `sales_orders_export` requests",
               "type": "object",
               "properties": {
                 "Field": {
-                  "description": "The name of the field being requested, which will be sent as`custom_field_*` when chosen by the seller. This value is expected to be unique per integration.",
+                  "description": "The name of the field being requested, which will be sent as `custom_field_*` when chosen by the seller. This value is expected to be unique per integration.",
                   "type": "string"
                 },
                 "DisplayName": {


### PR DESCRIPTION
This adds the comments from https://github.com/ShipEngine/connect/pull/700 into the doc site.