### PR TITLE
Remove Coming Soon language

### DIFF
--- a/getting-started/initialize-project.mdx
+++ b/getting-started/initialize-project.mdx
@@ -2,17 +2,6 @@
 title: Initialize Project
 ---
 
-import {
-  FlexSection,
-  ThinTile,
-} from '@redocly/developer-portal/ui';
-import orderIcon from '../images/orders.svg';
-import packageIcon from '../images/package.svg';
-import truckIcon from '../images/shipping-truck.svg';
-import calculatorIcon from '../images/calculator.svg';
-import thirdPartyLogisticsIcon from '../images/third-party-logistics.svg';
-import cogBrowser from '../images/cog-browser.svg';
-
 # Initialize Project
 ## Connect Init
 The `init` command will begin the process of creating a new ShipEngine Connect application.
@@ -33,23 +22,8 @@ This will generate a project structure to help build your integration.
 
 ## Integration Types
 Learn more about the implementation details of the various ShipEngine Connect integration types.
-<FlexSection justifyContent="space-around" flexWrap="wrap">
-    <ThinTile header="Orders" icon={orderIcon} to="../orders/index.mdx">
-        Import Orders, Notify Marketplaces, etc...
-    </ThinTile>
-    <ThinTile header="Shipping" icon={packageIcon} to="../shipping/index.mdx">
-        Get Rates, Create Labels, Tracking, etc...
-    </ThinTile>
-    <ThinTile header="Inventory" icon={cogBrowser} >
-      Coming Soon...
-    </ThinTile>
-    <ThinTile header="3PL" icon={thirdPartyLogisticsIcon} >
-      Coming Soon...
-    </ThinTile>
-    <ThinTile header="Freight" icon={truckIcon} >
-        Coming Soon...
-    </ThinTile>
-    <ThinTile header="Native Rating" icon={calculatorIcon} >
-        Coming Soon...
-    </ThinTile>
-  </FlexSection>
+
+* [Orders](../orders/index.mdx) - Import Orders, Notify Marketplaces, push and pull inventory
+* [Shipping](../shipping/index.mdx) - Create Labels, Calculate or Retrieve Rates, Tracking
+* [3PL](../fulfillment-provider/index.mdx) - Delegate orders, shipping notifications, etc...
+* [Freight](../freight/index.md) - LTL

--- a/index.mdx
+++ b/index.mdx
@@ -54,14 +54,14 @@ export default LandingLayout;
     <ThinTile header="Shipping" icon={packageIcon} to="./shipping/index.mdx">
       Get Rates, Create Labels, Tracking, etc...
     </ThinTile>
-    <ThinTile header="Inventory" icon={cogBrowser}>
-      Coming Soon...
+    <ThinTile header="Inventory" icon={cogBrowser} to="./inventory/index.md">
+      Import or publish inventory levels
     </ThinTile>
     <ThinTile header="3PL" icon={thirdPartyLogisticsIcon} to="./fulfillment-provider/index.mdx">
       Delegate orders, shipping notifications, rates, etc...
     </ThinTile>
-    <ThinTile header="Freight" icon={truckIcon}>
-      Coming Soon...
+    <ThinTile header="Freight" icon={truckIcon} to="./freight/index.md">
+      LTL
     </ThinTile>
     <ThinTile
       header="Native Rating"


### PR DESCRIPTION
Link to documentation pages for Inventory and Freight from the home page.

Remove the duplicate 'tiles' display for integration types on the 'Initialize Project' page.
It was out of sync with the list on the home page. Just provide links for the main app types.