### PR TITLE
Freight page - intro summary and initial metadata documentation

### DIFF
--- a/freight/index.md
+++ b/freight/index.md
@@ -1,4 +1,0 @@
----
-title: Freight
----
-# Freight

--- a/freight/index.mdx
+++ b/freight/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Freight
+---
+# Freight
+import { JsonSchema } from "@redocly/developer-portal/ui";
+import Schema from "./metadata-schema.json";
+
+Connect supports building custom integrations for LTL freight carriers to make them available via the ShipEngine API, allowing users to connect their accounts, create quotes, schedule pickups, track their shipments and more.
+
+## Metadata Definition
+<JsonSchema
+  schema={Schema}
+/>

--- a/freight/metadata-schema.json
+++ b/freight/metadata-schema.json
@@ -1,0 +1,364 @@
+{
+    "type": "object",
+    "required": [
+        "Id",
+        "ApiCode",
+        "Name",
+        "FreightCarriers",
+        "Connector"
+    ],
+    "properties": {
+        "Id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id for the freight app **(this GUID should not be changed after publishing)**"
+        },
+        "ApiCode": {
+            "type": "string",
+            "description": "The identifier for the freight app that will be used to route requests to the module. Must be snake cased and unique"
+        },
+        "Name": {
+            "type": "string",
+            "description": "The name of the freight app"
+        },
+        "FreightCarriers": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "description": "The freight carriers supported by the freight app",
+            "items": {
+                "type": "object",
+                "required": [
+                    "Id",
+                    "Codes",
+                    "Name",
+                    "Features",
+                    "ServiceLevels",
+                    "ContainerTypes",
+                    "AccessorialServiceGroups",
+                    "DocumentTypes",
+                    "Countries",
+                    "AccountConnection",
+                    "Images"
+                ],
+                "properties": {
+                    "Id": {
+                        "type": "string",
+                        "description": "The id for the freight carrier **(this GUID should not be changed after publishing)**"
+                    },
+                    "Codes": {
+                        "type": "array",
+                        "description": "The codes used to identify the freight carrier",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "SCAC",
+                                "ApiCode"
+                            ],
+                            "properties": {
+                                "SCAC": {
+                                    "type": "string",
+                                    "description": "The Standard Carrier Alpha Code for the carrier"
+                                },
+                                "ApiCode": {
+                                    "type": "string",
+                                    "description": "The identifier for the freight carrier to be used in API calls. Must be snake cased and unique"
+                                }
+                            }
+                        }
+                    },
+                    "Name": {
+                        "type": "string",
+                        "description": "The name of the freight carrier"
+                    },
+                    "Features": {
+                        "type": "array",
+                        "description": "The features supported by the carrier",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "AutoPRO",
+                                "Connect",
+                                "Documents",
+                                "Quote",
+                                "SchedulePickup",
+                                "Tracking"
+                            ]
+                        }
+                    },
+                    "ServiceLevels": {
+                        "type": "array",
+                        "description": "The service levels supported by the carrier",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "Id",
+                                "ApiCode",
+                                "Code",
+                                "Name",
+                                "Features"
+                            ],
+                            "properties": {
+                                "Id": {
+                                    "type": "string"
+                                },
+                                "ApiCode": {
+                                    "type": "string"
+                                },
+                                "Code": {
+                                    "type": "string"
+                                },
+                                "Name": {
+                                    "type": "string"
+                                },
+                                "Features": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [
+                                            "AutoPRO",
+                                            "Connect",
+                                            "Documents",
+                                            "Quote",
+                                            "SchedulePickup",
+                                            "Tracking"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "ContainerTypes": {
+                        "type": "array",
+                        "description": "The container types supported by the carrier",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "Id",
+                                "ApiCode",
+                                "Code",
+                                "Name",
+                                "Features"
+                            ],
+                            "properties": {
+                                "Id": {
+                                    "type": "string"
+                                },
+                                "ApiCode": {
+                                    "type": "string"
+                                },
+                                "Code": {
+                                    "type": "string"
+                                },
+                                "Name": {
+                                    "type": "string"
+                                },
+                                "Features": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [
+                                            "AutoPRO",
+                                            "Connect",
+                                            "Documents",
+                                            "Quote",
+                                            "SchedulePickup",
+                                            "Tracking"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "AccessorialServiceGroups": {
+                        "type": "array",
+                        "description": "The accessorial services supported by the carrier, grouped and sorted as required",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "Id",
+                                "Name",
+                                "SortOrder",
+                                "Services"
+                            ],
+                            "properties": {
+                                "Id": {
+                                    "type": "string"
+                                },
+                                "Name": {
+                                    "type": "string"
+                                },
+                                "SortOrder": {
+                                    "type": "integer",
+                                    "default": 0
+                                },
+                                "Services": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": [
+                                            "Id",
+                                            "ApiCode",
+                                            "Code",
+                                            "Name",
+                                            "Features",
+                                            "ResponseOnly",
+                                            "Attributes"
+                                        ],
+                                        "properties": {
+                                            "Id": {
+                                                "type": "string"
+                                            },
+                                            "ApiCode": {
+                                                "type": "string"
+                                            },
+                                            "Code": {
+                                                "type": "string"
+                                            },
+                                            "Name": {
+                                                "type": "string"
+                                            },
+                                            "Features": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "AutoPRO",
+                                                        "Connect",
+                                                        "Documents",
+                                                        "Quote",
+                                                        "SchedulePickup",
+                                                        "Tracking"
+                                                    ]
+                                                }
+                                            },
+                                            "ResponseOnly": {
+                                                "type": "boolean"
+                                            },
+                                            "Attributes": {
+                                                "type": "object",
+                                                "required": [
+                                                    "JsonSchema",
+                                                    "UiSchema",
+                                                    "ApiContractMapping"
+                                                ],
+                                                "properties": {
+                                                    "JsonSchema": {
+                                                        "type": "object"
+                                                    },
+                                                    "UiSchema": {
+                                                        "type": "object"
+                                                    },
+                                                    "ApiContractMapping": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "apiContractField",
+                                                                "jsonSchemaProperty"
+                                                            ],
+                                                            "properties": {
+                                                                "apiContractField": {
+                                                                    "type": "string"
+                                                                },
+                                                                "jsonSchemaProperty": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "DocumentTypes": {
+                        "type": "array",
+                        "description": "The document types supported by the carrier",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "Countries": {
+                        "type": "array",
+                        "description": "The countries supported by the carrier",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "AccountConnection": {
+                        "type": "object",
+                        "description": "The connection forms for the carrier, as well as the API contract mapping for use in ShipEngine",
+                        "required": [
+                            "JsonSchema",
+                            "UiSchema",
+                            "ApiContractMapping"
+                        ],
+                        "properties": {
+                            "JsonSchema": {
+                                "type": "object"
+                            },
+                            "UiSchema": {
+                                "type": "object",
+                                "required": [
+                                    "account_number"
+                                ],
+                                "properties": {
+                                    "account_number": {
+                                        "type": "object",
+                                        "required": [
+                                            "ui:autofocus"
+                                        ],
+                                        "properties": {
+                                            "ui:autofocus": {
+                                                "type": "boolean",
+                                                "default": false
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "ApiContractMapping": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": [
+                                        "apiContractField",
+                                        "jsonSchemaProperty"
+                                    ],
+                                    "properties": {
+                                        "apiContractField": {
+                                            "type": "string"
+                                        },
+                                        "jsonSchemaProperty": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "Images": {
+                        "type": "object",
+                        "description": "The logo and icon images for the carrier",
+                        "required": [
+                            "LogoUrl",
+                            "IconUrl"
+                        ],
+                        "properties": {
+                            "LogoUrl": {
+                                "type": "string"
+                            },
+                            "IconUrl": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/getting-started/initialize-project.mdx
+++ b/getting-started/initialize-project.mdx
@@ -33,27 +33,28 @@ This will generate a project structure to help build your integration.
 
 ## Integration Types
 Learn more about the implementation details of the various ShipEngine Connect integration types.
+
 <FlexSection justifyContent="space-around" flexWrap="wrap">
     <ThinTile header="Orders" icon={orderIcon} to="../orders/index.mdx">
-      Import Orders, Notify Marketplaces, etc...
+        Import Orders, Notify Marketplaces, etc...
     </ThinTile>
     <ThinTile header="Shipping" icon={packageIcon} to="../shipping/index.mdx">
-      Get Rates, Create Labels, Tracking, etc...
+        Get Rates, Create Labels, Tracking, etc...
     </ThinTile>
     <ThinTile header="Inventory" icon={cogBrowser} to="../inventory/index.md">
-      Import or publish inventory levels
+        Import or publish inventory levels
     </ThinTile>
     <ThinTile header="3PL" icon={thirdPartyLogisticsIcon} to="../fulfillment-provider/index.mdx">
-      Delegate orders, shipping notifications, rates, etc...
+        Delegate orders, shipping notifications, rates, etc...
     </ThinTile>
     <ThinTile header="Freight" icon={truckIcon} to="../freight/index.md">
-      LTL
+        LTL - Create Quotes, Schedule Pickups, Tracking, etc...
     </ThinTile>
     <ThinTile
-      header="Native Rating"
-      icon={calculatorIcon}
-      to="../native-rating/index.md"
+        header="Native Rating"
+        icon={calculatorIcon}
+        to="../native-rating/index.md"
     >
-      Implement Rating, Define Rate Cards, etc ...
+        Implement Rating, Define Rate Cards, etc ...
     </ThinTile>
-  </FlexSection>
+</FlexSection>

--- a/getting-started/initialize-project.mdx
+++ b/getting-started/initialize-project.mdx
@@ -47,7 +47,7 @@ Learn more about the implementation details of the various ShipEngine Connect in
     <ThinTile header="3PL" icon={thirdPartyLogisticsIcon} to="../fulfillment-provider/index.mdx">
         Delegate orders, shipping notifications, rates, etc...
     </ThinTile>
-    <ThinTile header="Freight" icon={truckIcon} to="../freight/index.md">
+    <ThinTile header="Freight" icon={truckIcon} to="../freight/index.mdx">
         LTL - Create Quotes, Schedule Pickups, Tracking, etc...
     </ThinTile>
     <ThinTile

--- a/index.mdx
+++ b/index.mdx
@@ -60,8 +60,8 @@ export default LandingLayout;
     <ThinTile header="3PL" icon={thirdPartyLogisticsIcon} to="./fulfillment-provider/index.mdx">
       Delegate orders, shipping notifications, rates, etc...
     </ThinTile>
-    <ThinTile header="Freight" icon={truckIcon} to="./freight/index.md">
-      LTL
+    <ThinTile header="Freight" icon={truckIcon} to="./freight/index.mdx">
+      LTL - Create Quotes, Schedule Pickups, Tracking, etc...
     </ThinTile>
     <ThinTile
       header="Native Rating"

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -28,7 +28,7 @@ shipping:
     pages:
       - page: shipping/reference.page.yaml/*
 freight:
-  - page: freight/index.md
+  - page: freight/index.mdx
   - group: Methods
     expanded: true
     pages:


### PR DESCRIPTION
Just so there's something more than a blank page when you click on the Freight icon...

Updated the tile on the home page:

<img width="231" alt="image" src="https://user-images.githubusercontent.com/42413/216432109-67b8c84b-a97d-4907-923a-aaf2d802a19c.png">

Freight page updated:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/42413/216432169-ed4c0349-e4af-40ed-a480-8b018f49476f.png">

Created a JSON schema for the metadata - didn't document every single property, but enough for show:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/42413/216432478-4bf64130-a8c3-4d9d-a275-44c3dd2edf63.png">
