### PR TITLE
Update Native Rating docs

### DIFF
--- a/native-rating/implementation.md
+++ b/native-rating/implementation.md
@@ -6,36 +6,7 @@ title: Building an Implementation
 
 ## Setup
 
-### Install the CLI
-
-First, ensure that you have [Node](https://nodejs.org/en/) v12+ and [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed. Mac users will also need the development tools installed, but you will be prompted to install them when you run the CLI.
-
-To install [ShipEngine Connect CLI](https://connect.shipengine.com/), run the following command from your terminal:
-
-```bash
-npm install --global @shipengine/connect
-```
-
-Verify that the CLI was installed correctly:
-
-```bash
-connect --version
-```
-
-### Create the Native Rating app
-
-The Connect CLI can create a Carrier app with Native Rating for you by running the following from your command line,
-replacing `my-native-rating-app` with the path you want to use for the app:
-
-```bash
-mkdir my-native-rating-app
-cd my-native-rating-app
-connect init
-```
-
-As you work through the wizard to create the Connect app, you will need to answer 'Y' to the question `will this app use native rating`. This will set up the build configuration for the rating logic.
-
-When this is finished, you will have a "fully working" Carrier connect app that uses Native Rating, ready to be modified however you see fit.
+Follow the [getting started](/getting-started/installing-nodejs/) walkthrough. On the [Initialize Project](/getting-started/initialize-project/) step, choose `Carrier app` when asked "what type of app are you building" and answer `Y` when asked "will this app use native rating". When this is finished, you will have a "fully working" Carrier connect app that uses Native Rating, ready to be modified however you see fit.
 
 ## Configuration
 

--- a/native-rating/implementation.md
+++ b/native-rating/implementation.md
@@ -14,7 +14,7 @@ Before building your implementation, it is recommended to get the basic configur
 
 ### DefaultRateCardId
 
-The `DefaultRateCardId` property is the only value required to use Native Rating for your Carrier app. This rate card will be used for any customer that does not have a rate card id specified in their seller provider settings. If all rate cards are managed via Connect, then this id should match the id of one of the rate cards defined in the `RateCards` property discussed below. If this id does _not_ match a rate card defined in the `RateCards` property, then a rate card with that id should be created manually through the Native Rating management API directly or else the Native Rating system will return an error when attempting to get rates. This value can be changed at any time.
+The `DefaultRateCardId` property is the only value required to use Native Rating for your Carrier app. This rate card will be used for any customer that does not have a rate card identifier specified in their seller provider settings. If all rate cards are managed via Connect, then this value should match the identifier of one of the rate cards defined in the `RateCards` property discussed below. If it does _not_ match a rate card defined in the `RateCards` property, then a rate card with that identifier should be created manually through the Native Rating management API directly or else the Native Rating system will return an error when attempting to get rates. This value can be changed at any time.
 
 ### RateCards
 
@@ -110,7 +110,7 @@ you don't modify this if you can avoid it. As before, it's worth keeping a backu
 The Connect tooling provides a simple test server that you can use to test your app. To start it, run the following commands:
 
 ```bash
-npm run build   # Run before first start and after any other Connect changes
+npm run build   # Run before first start and after any non-rating changes
 npm run bundle  # Run after any rating implementation changes
 npm start
 ```
@@ -132,7 +132,7 @@ All users will get rates from the default rate card defined in the carrier defin
 
 ### Publishing the Native Rating app
 
-When the implementation is complete, you can use the Connect CLI to publish the Carrier app to the development
+When the implementation is complete, you can use the Connect CLI to publish the app to the development
 environment for live testing. To do this, ensure that the package is built and bundled by running the following:
 
 ```bash

--- a/native-rating/index.md
+++ b/native-rating/index.md
@@ -18,7 +18,9 @@ Changes that you make to rate cards, zone sets, and rating logic are not immedia
 
 To test rates that are in development, you can make a rates request like you normally would with the addition of a special header: `request-date: unpublished`. This will instruct the Native Rating service to use the absolute newest data and logic whether it has been published or not. You can also use that header to request historical data by passing a date, like this: `request-date: 2021-11-03T09:34:16.123Z`. This would cause the Native Rating service to use the published data and logic as of the specified date. If you want the most current published rates, it's best to omit the `request-date` header rather than passing the current date and time in because the Native Rating service has performance optimizations for currently published rates that are bypassed when a date is specified.
 
-**NOTE:** Once rates are published, they CANNOT be unpublished. There is a mechanism to re-publish the previously published data, however. The end result for live data is the same as unpublishing but the distinction is that if a request is made using the `request-date` header with the date and time that is within the window that the unwanted published data was available, those rates will still be served.
+:::warning Note
+Once rates are published, they CANNOT be unpublished. There is a mechanism to re-publish the previously published data, however. The end result for live data is the same as unpublishing but the distinction is that if a request is made using the `request-date` header with the date and time that is within the window that the unwanted published data was available, those rates will still be served.
+:::
 
 ## Workflow
 

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1498,6 +1498,48 @@
           "RequiresLabelPayment": {
             "type": "boolean",
             "description": "Indicates whether the carrier requires the label be purchased on calling create label"
+          },
+          "NativeRating": {
+            "type": "object",
+            "description": "If this carrier uses Native Rating, details about the connection",
+            "additionalProperties": false,
+            "properties": {
+              "DefaultRateCardId": {
+                "type": "string",
+                "description": "The id of the default rate card to use for this carrier"
+              },
+              "Path": {
+                "type": "string",
+                "description": "The path to rating logic and rate card data for this carrier"
+              },
+              "RateCards": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": "string",
+                      "description": "Externally facing id of the rate card."
+                    },
+                    "Currency": {
+                      "type": "string",
+                      "format": "^([A-Z]{3})$",
+                      "minLength": 3,
+                      "maxLength": 3,
+                      "description": "Currency of the rate card. This uses the three-character currency code format."
+                    }
+                  },
+                  "required": [
+                    "Id",
+                    "Name"
+                  ]
+                },
+                "description": "A list of rate cards available for this carrier"
+              }
+            },
+            "required": [ "DefaultRateCardId" ]
           }
         },
         "required": [

--- a/shipping/rating.md
+++ b/shipping/rating.md
@@ -1,0 +1,9 @@
+---
+title: Rating
+---
+
+# Rating
+
+There are two ways a carrier can provide rates for a shipment. The simplest way is to implement the [GetRates](/shipping/reference/operation/GetRates/) method of the Carrier API app. This method can be used to make a request to the carrier's rating API, if it has one, or to calculate rates locally. This approach works well when the rating logic and data will not change often. If the data does change often, or if separate rate cards are needed for different customers, it can be challenging to manage using this method.
+
+In that scenario, the carrier can use the alternate method of providing rates which is to use the [Native Rating](/native-rating/) system. It is not as simple to set up, but it allows much more control over the logic and data and can be customized per seller.

--- a/shipping/rating.md
+++ b/shipping/rating.md
@@ -4,6 +4,12 @@ title: Rating
 
 # Rating
 
-There are two ways a carrier can provide rates for a shipment. The simplest way is to implement the [GetRates](/shipping/reference/operation/GetRates/) method of the Carrier API app. This method can be used to make a request to the carrier's rating API, if it has one, or to calculate rates locally. This approach works well when the rating logic and data will not change often. If the data does change often, or if separate rate cards are needed for different customers, it can be challenging to manage using this method.
+There are two different approaches to implement rating functionality in your app.
 
-In that scenario, the carrier can use the alternate method of providing rates which is to use the [Native Rating](/native-rating/) system. It is not as simple to set up, but it allows much more control over the logic and data and can be customized per seller.
+## GetRates
+
+The most common approach is to implement the [GetRates](/shipping/reference/operation/GetRates/) method of the Carrier API. The GetRates implementation can do whatever it needs to do to calculate the rate. Usually that means calling out to an HTTP API provided by the carrier. But if the rating logic is simple enough, and does not change too often, it can be implemented directly in the GetRates method.
+
+## Native Rating
+
+An alternate approach is to take advantage of our [Native Rating](/native-rating/) system, which is designed to support scenarios where complex rating logic is needed and an adequate HTTP API is not available.  For example, it can manage multiple rate cards that vary per customer, and vary over time. It requires some extra implementation steps beyond just implementing a single function, but it allows much more control over the logic and data, allowing both to vary based on the customer or the time of the request (to account for rate changes, etc).

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -22,6 +22,7 @@ shipping:
   - page: shipping/error-handling.md
   - page: shipping/testing-guide.mdx
   - page: shipping/environment-variables.md
+  - page: shipping/rating.md
   - page: shipping/forms.md
   - group: Methods
     expanded: true


### PR DESCRIPTION
This PR updates the documentation for Native Rating to reflect the recent merge of the Native Rating functionality into the CAPI package.  The Native Rating specific documentation has been updated to reflect this and an extra page has been added to the Shipping docs.