### PR TITLE
Update the urls to the OnTrac and PrestaShop example apps

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -80,7 +80,7 @@ export default LandingLayout;
       icon={ontrac}
       header="Shipping"
       target="_blank"
-      to="https://github.com/ShipEngine/connect-ontrac"
+      to="https://github.com/ShipEngine/connect-samples/tree/main/ontrac"
     >
       This is an example of a shipping integration built for Ontrac.
     </WideTile>
@@ -88,7 +88,7 @@ export default LandingLayout;
       icon={prestashop}
       header="Orders"
       target="_blank"
-      to="https://github.com/ShipEngine/connect-prestashop"
+      to="https://github.com/ShipEngine/connect-samples/tree/main/prestashop"
     >
       This is an example of an orders integration built for PrestaShop.
     </WideTile>


### PR DESCRIPTION
The OnTrac and PrestaShop example apps are being moved into the [connect-samples](https://github.com/ShipEngine/connect-samples) repository.  This PR updates the urls of the sample apps to reflect this.  This should not be merged until https://github.com/ShipEngine/connect-samples/pull/1 is approved and merged.