### PR TITLE
feat(): added new parameters regarding Windsor Framework in shipping metadata-schema.json

### DIFF
--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1351,7 +1351,28 @@
                 ],
                 "description": ""
               },
-              "windsor-framework-details": {
+              "windsor-framework-movement-indicator": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": ""
+              }
+               "windsor-framework-not-at-risk": {
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1371,7 +1371,7 @@
                   "Description"
                 ],
                 "description": ""
-              }
+              },
                "windsor-framework-not-at-risk": {
                 "type": "object",
                 "additionalProperties": false,


### PR DESCRIPTION
Added new parameters regarding The Windsor framework which is a new regulation in the UK that simplifies customs procedures for goods moved from the UK mainland to Northern Ireland. As a part of the framework, the regulations related to B2B shipments, including parcels, have been aligned with the existing regulations that have been used so far only for freight shipping.

JIRA: https://auctane.atlassian.net/browse/GOLD-6751