### PR TITLE
Shipping option dangerous-goods-simple added

### DIFF
--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -973,7 +973,7 @@
                   "Name",
                   "Description"
                 ],
-                 "description": "Indicates if the Dangerous goods are present in the shipment"
+                 "description": "Indicates if the Dangerous goods are present in the shipment. This object determines that Contact name and phone should be available in the ui"
               },
               "dangerous-goods-simple": {
                 "type": "object",

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -973,7 +973,28 @@
                   "Name",
                   "Description"
                 ],
-                "description": ""
+                 "description": "Indicates if the Dangerous goods are present in the shipment"
+              },
+              "dangerous-goods-simple": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": "Indicates if the Dangerous goods are present in the shipment"
               },
               "delivery-message": {
                 "type": "object",

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -973,7 +973,7 @@
                   "Name",
                   "Description"
                 ],
-                 "description": "Indicates if the Dangerous goods are present in the shipment. This object determines that Contact name and phone should be available in the ui"
+                 "description": "Indicates if the Dangerous goods are present in the shipment. This object determines that Contact name and phone should be provided"
               },
               "dangerous-goods-simple": {
                 "type": "object",


### PR DESCRIPTION
Shipping option dangerous-goods-simple added
UI should support three types of dangerous goods (related [SPD-18136](https://auctane.atlassian.net/browse/SPD-18136)):
- dangerous-goods → checkbox + DG contact with two fields name and phone
- dangerous-goods-simple → checkbox
- dangerous-goods-legacy → checkbox + DG type + DG contact field
It was agreed with @uwilczak that the legacy option will not list in the public documentation

[SPD-18191](https://auctane.atlassian.net/browse/SPD-18191)

**Before**:
![image](https://github.com/user-attachments/assets/13490105-87e4-4a2e-8f4d-591f4456b533)

**After**:
![image](https://github.com/user-attachments/assets/8ca53ee1-1b1e-4607-95db-7bd5b5bd155b)


[SPD-18136]: https://auctane.atlassian.net/browse/SPD-18136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPD-18191]: https://auctane.atlassian.net/browse/SPD-18191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ