### PR TITLE
feat: add TrackingSubscriptionLevel to DemoCarrier and metadata schema

### DIFF
--- a/shipping/index.mdx
+++ b/shipping/index.mdx
@@ -37,6 +37,7 @@ import {
   LabelFormatsEnum,
   ShippingOptionEnum,
   ConfirmationTypeEnum,
+  TrackingSubscriptionLevel,
 } from '@shipengine/connect-carrier-api';
 import { join } from 'path';
 import { Box, Bag } from './packaging';
@@ -48,6 +49,7 @@ export const DemoCarrier: Carrier = {
   Name: 'Demo Carrier',
   ApiCode: 'demo_carrier_code',
   Description: 'This is a description about the carrier',
+  TrackingSubscriptionLevel: TrackingSubscriptionLevel.Account,
   PackageTypes: [Box, Bag],
   ShippingServices: [NextDayAir, BudgetDelivery],
   ShippingOptions: {

--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1548,6 +1548,20 @@
             "maxLength": 200,
             "description": "This is the url template for static tracking pages ex: `http://www.shipper.com/tracking/{0}`"
           },
+          "TrackingSubscriptionLevel": {
+            "type": "string",
+            "enum": [
+              "None",
+              "TrackingNumber",
+              "Account"
+            ],
+            "description": "Defines the subscription level required for a carrier to provide tracking updates.",
+            "x-enumDescriptions": {
+              "None": "The carrier does not require any tracking subscription.",
+              "TrackingNumber": "The carrier requires a tracking subscription on a per tracking number basis.",
+              "Account": "The carrier requires a tracking subscription on a per account basis."
+            }
+          },
           "CarrierUrl": {
             "type": "string",
             "format": "uri",


### PR DESCRIPTION
Add TrackingSubscriptionLevel to DemoCarrier and metadata schema.
<img width="694" height="720" alt="obraz" src="https://github.com/user-attachments/assets/6ad63bd1-f2b6-41e6-8ee4-6bef34ff0ec0" />
<img width="912" height="455" alt="obraz" src="https://github.com/user-attachments/assets/e4c246c3-1c99-4005-a606-9df251843e01" />

JIRA: https://auctane.atlassian.net/browse/GOLD-17399