### PR TITLE
feat(shipping): fragile shipping option added

### DIFF
--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1439,6 +1439,27 @@
                 ],
                 "description": ""
               },
+              "fragile": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": "Indicates that the contents of the package are fragile and should be handled with care."
+              },
               "delivery-as-addressed": {
                 "type": "object",
                 "additionalProperties": false,


### PR DESCRIPTION
This pull request adds a new property to the shipping metadata schema to support marking packages as fragile. This enhancement allows for more accurate handling instructions in shipping workflows.

**Schema enhancements:**

* Added a `fragile` object property to the `shipping/metadata-schema.json` file, with required fields `Name` and `Description`, to indicate that a package contains fragile contents and should be handled with care.

JIRA: https://auctane.atlassian.net/browse/GOLD-20841