### PR TITLE
feat(carrier-api): fragile shipping option added

### DIFF
--- a/shipping/metadata-schema.json
+++ b/shipping/metadata-schema.json
@@ -1439,6 +1439,27 @@
                 ],
                 "description": ""
               },
+              "fragile": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "Name": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "description": ""
+                  },
+                  "Description": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": ""
+                  }
+                },
+                "required": [
+                  "Name",
+                  "Description"
+                ],
+                "description": "Indicates that the contents of the package are fragile and should be handled with care."
+              },
               "delivery-as-addressed": {
                 "type": "object",
                 "additionalProperties": false,


### PR DESCRIPTION
This pull request adds support for specifying fragile items in the shipping metadata schema. The main change is the introduction of a new `fragile` property, allowing packages to be marked as fragile with a name and description.

**Shipping metadata schema update:**

* Added a new `fragile` property to the `shipping/metadata-schema.json` schema, which is an object requiring `Name` and `Description` fields to indicate that the package contents are fragile and should be handled with care.

JIRA: https://auctane.atlassian.net/browse/GOLD-20841